### PR TITLE
feat: add CI retry, web dashboard, and dashboard CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ src/
 ├── stall-monitor.ts      # Log file growth monitor
 ├── log.ts                # Colored console logging
 ├── summary.ts            # Data-driven summary table renderer
-├── watch.ts              # Live dashboard
+├── watch.ts              # Live terminal dashboard
 ├── pr-tracker.ts         # PR URL extraction from logs
 ├── merge.ts              # PR merge with rebase
 ├── run-history.ts        # Run record persistence
@@ -30,6 +30,15 @@ src/
 ├── yaml-schema.ts        # Zod schema for YAML config validation
 ├── yaml-hooks.ts         # deriveHooks() — YAML fields → OrchestratorHooks
 ├── yaml-loader.ts        # loadYamlConfig() — full YAML→config pipeline
+├── github.ts             # GitHub CLI wrapper (labels, comments)
+├── upstream-context.ts   # HANDOFF.md reading for agent-to-agent context
+├── issue-comments.ts     # Post run summary comments on GitHub issues
+├── label-sync.ts         # GitHub label sync on status changes
+├── decompose.ts          # LLM-driven task decomposition
+├── decompose-types.ts    # Decompose input/output types
+├── dashboard.ts          # HTTP dashboard server with SSE
+├── dashboard-types.ts    # Dashboard dependency/option types
+├── dashboard-html.ts     # Self-contained HTML template
 ├── index.ts              # Public API barrel export
 └── testing.ts            # Test utility exports
 ```
@@ -45,6 +54,74 @@ src/
   a YAML file, validates it, derives convention-based hooks, and merges
   optional `.hooks.ts` overrides. `setUpWorktree`/`removeWorktree` must be
   provided via overrides (no universal default).
+- **Status change hooks**: `onStatusChange` hook in `OrchestratorHooks` is called on every status transition via `setStatus()`. Used by label sync. Errors are non-fatal.
+- **CI retry**: When `retryOnCheckFailure` is configured, failed `postSessionCheck` results trigger automatic re-runs with failure context injected into the prompt.
+
+### YAML Config Fields
+
+```yaml
+name: "project-name"
+configDir: ".orchestrator/config"
+worktreeDir: ".worktrees"
+projectRoot: "."
+stallTimeout: 600
+promptTemplate: "prompt.md"
+branchPrefix: "orchestrator/"
+
+# Post-session validation commands
+postSessionCheck:
+  commands: ["npm test", "npm run typecheck"]
+  cwd: "."  # optional, relative to worktree
+
+# Auto-retry on check failure
+retryOnCheckFailure:
+  maxRetries: 2
+  enabled: true  # defaults to true if omitted
+
+# Post run summary comments on GitHub issues
+issueComments:
+  repo: "owner/repo"
+  enabled: true  # defaults to true if omitted
+
+# Sync status labels on GitHub issues
+labelSync:
+  prefix: "orchestrator"
+  repo: "owner/repo"  # optional, falls back to issue-level repo
+
+# Template variables: {{ISSUE_NUMBER}}, {{SLUG}}, {{DESCRIPTION}},
+# {{projectRoot}}, {{configDir}}, {{worktreeDir}}, {{UPSTREAM_CONTEXT}}
+
+issues:
+  - number: 1
+    slug: feature-name
+    dependsOn: []
+    description: "Feature description"
+```
+
+### CLI Modes
+
+```bash
+<script> <config> [options]
+  --help, -h         Show help
+  --status           Show current issue statuses
+  --watch            Live terminal dashboard
+  --dashboard        Web dashboard (HTTP + SSE)
+  --port <n>         Port for web dashboard (default: 3000)
+  --merge            Merge succeeded PRs
+  --cleanup          Remove worktrees and branches
+  --retry-failed     Retry failed issues
+  --tail             Reattach to detached run
+  --decompose        LLM-driven task decomposition
+  --file <path>      Input file for decompose
+  --issue <n>        GitHub issue number for decompose
+  --repo <owner/repo>  Repository for decompose/issue creation
+  --create-issues    Create GitHub issues from decompose output
+  --wave <n>         Run specific wave
+  --parallel <n>     Max parallel sessions (default: 4)
+  --merge-after-wave Merge PRs after each wave
+  --detach           Run in background
+  --notify           macOS notification on completion
+```
 
 ### Commands
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,43 @@ Each config provides an `OrchestratorHooks` object:
 | `interpolatePrompt(issue)` | Build the Claude prompt |
 | `getClaudeArgs(issue)` | Extra CLI args for claude |
 | `printSummary(issues, getStatus)` | Display status table |
-| `postSessionCheck?(issue, path)` | Optional post-session validation |
+| `postSessionCheck?(issue, path)` | Optional post-session validation (returns `PostCheckResult` with `passed`, `summary`, `output`) |
+| `onStatusChange?(issue, old, new)` | Optional hook called on every status transition (used by label sync) |
+
+### Agent-to-Agent Communication
+
+Upstream agents can write a `HANDOFF.md` file in their worktree root. When downstream issues start, the orchestrator reads `HANDOFF.md` from each dependency's worktree and injects the content into the prompt template via `{{UPSTREAM_CONTEXT}}`.
+
+### GitHub Integration
+
+- **Issue comments**: Set `issueComments: { repo: "owner/repo" }` in YAML to post run summary comments on GitHub issues after each run.
+- **Label sync**: Set `labelSync: { prefix: "orchestrator" }` in YAML to sync status labels (e.g., `orchestrator:running`, `orchestrator:succeeded`) on GitHub issues as statuses change.
+
+### CI Failure Retry
+
+Set `retryOnCheckFailure: { maxRetries: 2 }` in YAML to automatically retry agent sessions when `postSessionCheck` fails. The failure output is injected into the retry prompt so the agent has context to fix the issues.
+
+### Task Decomposition
+
+Use `--decompose` to invoke an LLM to break a feature description into structured issues:
+
+```bash
+echo "Add user authentication with OAuth" | npx tsx orchestrate.ts myconfig --decompose
+npx tsx orchestrate.ts myconfig --decompose --file spec.md
+npx tsx orchestrate.ts myconfig --decompose --issue 42 --repo owner/repo
+npx tsx orchestrate.ts myconfig --decompose --file spec.md --create-issues --repo owner/repo
+```
+
+### Web Dashboard
+
+Use `--dashboard` to start a read-only HTTP dashboard with live status updates:
+
+```bash
+npx tsx orchestrate.ts myconfig --dashboard              # http://127.0.0.1:3000
+npx tsx orchestrate.ts myconfig --dashboard --port 8080   # custom port
+```
+
+The dashboard shows issues grouped by wave with status badges, PR links, and expandable log tails. Updates are streamed via Server-Sent Events.
 
 ## Test Utilities
 

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -194,4 +194,25 @@ describe("parseArgs", () => {
       expect(result.createIssues).toBe(true);
     });
   });
+
+  describe("dashboard flags", () => {
+    it("parses --dashboard", () => {
+      const result = parseArgs(["--dashboard"]);
+      expect(result.mode).toBe("dashboard");
+    });
+
+    it("parses --dashboard with --port", () => {
+      const result = parseArgs(["--dashboard", "--port", "8080"]);
+      expect(result.mode).toBe("dashboard");
+      expect(result.port).toBe(8080);
+    });
+
+    it("throws when --port has no value", () => {
+      expect(() => parseArgs(["--port"])).toThrow("--port requires a number");
+    });
+
+    it("throws when --port value starts with -", () => {
+      expect(() => parseArgs(["--port", "--dashboard"])).toThrow("--port requires a number");
+    });
+  });
 });

--- a/__tests__/dashboard.test.ts
+++ b/__tests__/dashboard.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { createDashboardServer } from "../src/dashboard.js";
+import { InMemoryStatusStore, InMemoryMetadataStore } from "../src/status.js";
+import { createSilentLogger } from "../src/log.js";
+import type { OrchestratorConfig, Issue } from "../src/types.js";
+import type { DashboardDeps } from "../src/dashboard-types.js";
+import type { DashboardHandle } from "../src/dashboard-types.js";
+
+function makeIssue(overrides: Partial<Issue> & { number: number }): Issue {
+  return {
+    slug: `issue-${overrides.number}`,
+    description: `Issue ${overrides.number}`,
+    dependsOn: [],
+    wave: 1,
+    deps: [],
+    ...overrides,
+  };
+}
+
+function makeDeps(overrides: Partial<DashboardDeps> = {}): DashboardDeps {
+  const issues: Issue[] = [
+    makeIssue({ number: 1, slug: "auth", description: "Add auth", wave: 1 }),
+    makeIssue({ number: 2, slug: "api", description: "Add API", wave: 2, deps: [1] }),
+  ];
+
+  return {
+    statusStore: new InMemoryStatusStore(),
+    metadataStore: new InMemoryMetadataStore(),
+    config: {
+      name: "test-project",
+      configDir: "/tmp/test",
+      worktreeDir: "/tmp/worktrees",
+      projectRoot: "/tmp",
+      stallTimeout: 300,
+      issues,
+      hooks: {} as OrchestratorConfig["hooks"],
+    },
+    logger: createSilentLogger(),
+    readLogTail: () => "last log line",
+    ...overrides,
+  };
+}
+
+// Use a random port for each test to avoid conflicts
+let nextPort = 19100;
+function getPort(): number {
+  return nextPort++;
+}
+
+describe("dashboard server", () => {
+  let handle: DashboardHandle | undefined;
+
+  afterEach(async () => {
+    if (handle) {
+      await handle.close();
+      handle = undefined;
+    }
+  });
+
+  it("serves HTML on GET /", async () => {
+    const port = getPort();
+    handle = await createDashboardServer(makeDeps(), { port });
+
+    const res = await fetch(`http://127.0.0.1:${port}/`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+
+    const body = await res.text();
+    expect(body).toContain("test-project");
+    expect(body).toContain("<!DOCTYPE html>");
+  });
+
+  it("returns issue statuses on GET /api/status", async () => {
+    const deps = makeDeps();
+    deps.statusStore.set(1, "running");
+    deps.statusStore.set(2, "pending");
+    const port = getPort();
+    handle = await createDashboardServer(deps, { port });
+
+    const res = await fetch(`http://127.0.0.1:${port}/api/status`);
+    expect(res.status).toBe(200);
+
+    const data = await res.json() as Array<{ number: number; status: string }>;
+    expect(data).toHaveLength(2);
+    expect(data[0]).toMatchObject({ number: 1, status: "running", slug: "auth" });
+    expect(data[1]).toMatchObject({ number: 2, status: "pending", slug: "api" });
+  });
+
+  it("returns config on GET /api/config", async () => {
+    const port = getPort();
+    handle = await createDashboardServer(makeDeps(), { port });
+
+    const res = await fetch(`http://127.0.0.1:${port}/api/config`);
+    const data = await res.json() as { name: string; issues: Array<{ number: number; slug: string; wave: number }> };
+
+    expect(data.name).toBe("test-project");
+    expect(data.issues).toHaveLength(2);
+    expect(data.issues[0]).toMatchObject({ number: 1, slug: "auth", wave: 1 });
+    expect(data.issues[1]).toMatchObject({ number: 2, slug: "api", wave: 2 });
+  });
+
+  it("returns log tail on GET /api/logs/:issue", async () => {
+    const readLogTail = vi.fn().mockReturnValue("test output line");
+    const port = getPort();
+    handle = await createDashboardServer(makeDeps({ readLogTail }), { port });
+
+    const res = await fetch(`http://127.0.0.1:${port}/api/logs/1`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("test output line");
+    expect(readLogTail).toHaveBeenCalledWith(1, 8192);
+  });
+
+  it("returns fallback when log read fails", async () => {
+    const readLogTail = vi.fn().mockImplementation(() => { throw new Error("ENOENT"); });
+    const port = getPort();
+    handle = await createDashboardServer(makeDeps({ readLogTail }), { port });
+
+    const res = await fetch(`http://127.0.0.1:${port}/api/logs/99`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("(no log output)");
+  });
+
+  it("returns metadata on GET /api/metadata/:issue", async () => {
+    const deps = makeDeps();
+    deps.metadataStore.set(1, { prUrl: "https://github.com/test/pr/1", exitCode: 0 });
+    const port = getPort();
+    handle = await createDashboardServer(deps, { port });
+
+    const res = await fetch(`http://127.0.0.1:${port}/api/metadata/1`);
+    const data = await res.json() as { prUrl: string; exitCode: number };
+    expect(data.prUrl).toBe("https://github.com/test/pr/1");
+    expect(data.exitCode).toBe(0);
+  });
+
+  it("returns 404 for unknown routes", async () => {
+    const port = getPort();
+    handle = await createDashboardServer(makeDeps(), { port });
+
+    const res = await fetch(`http://127.0.0.1:${port}/api/unknown`);
+    expect(res.status).toBe(404);
+
+    const data = await res.json() as { error: string };
+    expect(data.error).toBe("Not found");
+  });
+
+  it("establishes SSE connection on GET /api/events", async () => {
+    const port = getPort();
+    handle = await createDashboardServer(makeDeps(), { port });
+
+    const res = await fetch(`http://127.0.0.1:${port}/api/events`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/event-stream");
+
+    // Clean up the SSE connection
+    if (res.body) {
+      await res.body.cancel();
+    }
+  });
+
+  it("emits SSE events when status changes", async () => {
+    const deps = makeDeps();
+    deps.statusStore.set(1, "pending");
+    const port = getPort();
+    handle = await createDashboardServer(deps, { port });
+
+    // Connect to SSE
+    const controller = new AbortController();
+    const res = await fetch(`http://127.0.0.1:${port}/api/events`, { signal: controller.signal });
+
+    // Change status — the polling interval is 2s, so we wait a bit
+    deps.statusStore.set(1, "succeeded");
+
+    // Read from the SSE stream
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+    let accumulated = "";
+    const timeout = Date.now() + 5000;
+
+    while (Date.now() < timeout) {
+      const { value, done } = await Promise.race([
+        reader.read(),
+        new Promise<{ value: undefined; done: true }>((resolve) =>
+          setTimeout(() => resolve({ value: undefined, done: true }), 3000)
+        ),
+      ]);
+      if (done && !accumulated.includes("event: status")) break;
+      if (value) accumulated += decoder.decode(value, { stream: true });
+      if (accumulated.includes("event: status")) break;
+    }
+
+    controller.abort();
+
+    expect(accumulated).toContain("event: status");
+    expect(accumulated).toContain('"succeeded"');
+  });
+});

--- a/__tests__/engine.test.ts
+++ b/__tests__/engine.test.ts
@@ -2113,3 +2113,122 @@ describe("onStatusChange hook", () => {
     );
   });
 });
+
+describe("CI failure retry", () => {
+  it("retries when postSessionCheck fails and retryOnCheckFailure is enabled", async () => {
+    let checkCallCount = 0;
+    const issue = makeIssue({ number: 1, wave: 1 });
+    const config = makeConfig([issue], {
+      postSessionCheck: vi.fn(async () => {
+        checkCallCount++;
+        if (checkCallCount === 1) {
+          return { passed: false, output: "test failed: assertion error", summary: "Tests failed" };
+        }
+        return { passed: true };
+      }),
+    });
+    config.retryOnCheckFailure = { maxRetries: 2, enabled: true };
+    const deps = makeDeps();
+    const orchestrator = new Orchestrator(config, deps);
+
+    const runner = deps.processRunner as ReturnType<typeof makeMockRunner>;
+    const promise = orchestrator.runWave(1);
+
+    // First spawn (original)
+    await vi.waitFor(() => expect(runner.spawned.length).toBe(1));
+    runner.resolvers.get(1000)!(0);
+
+    // Retry spawn
+    await vi.waitFor(() => expect(runner.spawned.length).toBe(2));
+    runner.resolvers.get(1001)!(0);
+
+    await promise;
+
+    expect(deps.statusStore.get(1)).toBe("succeeded");
+    expect(deps.metadataStore.get(1).retryCount).toBe(1);
+
+    // Retry prompt should contain failure context
+    const retryArgs = runner.spawned[1].args;
+    const promptIndex = retryArgs.indexOf("-p");
+    expect(retryArgs[promptIndex + 1]).toContain("CI Failure Context");
+    expect(retryArgs[promptIndex + 1]).toContain("test failed: assertion error");
+  });
+
+  it("marks as failed when all retries exhausted", async () => {
+    const issue = makeIssue({ number: 1, wave: 1 });
+    const config = makeConfig([issue], {
+      postSessionCheck: vi.fn(async () => ({
+        passed: false, output: "lint errors", summary: "Lint failed",
+      })),
+    });
+    config.retryOnCheckFailure = { maxRetries: 1, enabled: true };
+    const deps = makeDeps();
+    const orchestrator = new Orchestrator(config, deps);
+
+    const runner = deps.processRunner as ReturnType<typeof makeMockRunner>;
+    const promise = orchestrator.runWave(1);
+
+    // Original spawn
+    await vi.waitFor(() => expect(runner.spawned.length).toBe(1));
+    runner.resolvers.get(1000)!(0);
+
+    // Retry spawn
+    await vi.waitFor(() => expect(runner.spawned.length).toBe(2));
+    runner.resolvers.get(1001)!(0);
+
+    await promise;
+
+    expect(deps.statusStore.get(1)).toBe("failed");
+    expect(deps.logger.error).toHaveBeenCalledWith(
+      expect.stringContaining("failed after 1 retries"),
+    );
+  });
+
+  it("does not retry when retryOnCheckFailure is not enabled", async () => {
+    const issue = makeIssue({ number: 1, wave: 1 });
+    const { orchestrator, deps } = makeOrchestrator([issue], {
+      postSessionCheck: vi.fn(async () => ({
+        passed: false, summary: "Check failed",
+      })),
+    });
+
+    const runner = deps.processRunner as ReturnType<typeof makeMockRunner>;
+    const promise = orchestrator.runWave(1);
+    await vi.waitFor(() => expect(runner.spawned.length).toBe(1));
+    runner.resolvers.get(1000)!(0);
+    await promise;
+
+    // Only one spawn (no retry)
+    expect(runner.spawned.length).toBe(1);
+    expect(deps.statusStore.get(1)).toBe("failed");
+  });
+
+  it("passes output from postSessionCheck through to retry prompt", async () => {
+    let checkCallCount = 0;
+    const issue = makeIssue({ number: 1, wave: 1 });
+    const config = makeConfig([issue], {
+      postSessionCheck: vi.fn(async () => {
+        checkCallCount++;
+        if (checkCallCount === 1) {
+          return { passed: false, output: "error: unused variable 'x'" };
+        }
+        return { passed: true };
+      }),
+    });
+    config.retryOnCheckFailure = { maxRetries: 1, enabled: true };
+    const deps = makeDeps();
+    const orchestrator = new Orchestrator(config, deps);
+
+    const runner = deps.processRunner as ReturnType<typeof makeMockRunner>;
+    const promise = orchestrator.runWave(1);
+    await vi.waitFor(() => expect(runner.spawned.length).toBe(1));
+    runner.resolvers.get(1000)!(0);
+    await vi.waitFor(() => expect(runner.spawned.length).toBe(2));
+    runner.resolvers.get(1001)!(0);
+    await promise;
+
+    const retryArgs = runner.spawned[1].args;
+    const promptIndex = retryArgs.indexOf("-p");
+    expect(retryArgs[promptIndex + 1]).toContain("unused variable 'x'");
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -72,6 +72,21 @@ export function parseArgs(argv: string[]): ParsedArgs {
         i++;
         break;
 
+      case "--dashboard":
+        result.mode = "dashboard";
+        i++;
+        break;
+
+      case "--port": {
+        const next = argv[i + 1];
+        if (next === undefined || next.startsWith("-")) {
+          throw new Error("--port requires a number");
+        }
+        result.port = parseInt(next, 10);
+        i += 2;
+        break;
+      }
+
       case "--file": {
         const next = argv[i + 1];
         if (next === undefined || next.startsWith("-")) {

--- a/src/create-main.ts
+++ b/src/create-main.ts
@@ -183,6 +183,36 @@ export async function createMain(options: MainOptions): Promise<void> {
     return;
   }
 
+  // Handle dashboard
+  if (args.mode === "dashboard") {
+    const { createDashboardServer } = await import("./dashboard.js");
+    const dashboardHandle = await createDashboardServer({
+      statusStore: deps.statusStore,
+      metadataStore: deps.metadataStore,
+      config,
+      logger: deps.logger,
+      readLogTail: (issueNumber: number, maxBytes: number) => {
+        const logFile = path.join(config.configDir, "logs", `issue-${issueNumber}.log`);
+        const fd = fs.openSync(logFile, "r");
+        try {
+          const stat = fs.fstatSync(fd);
+          const start = Math.max(0, stat.size - maxBytes);
+          const buf = Buffer.alloc(Math.min(maxBytes, stat.size));
+          fs.readSync(fd, buf, 0, buf.length, start);
+          return buf.toString("utf-8");
+        } finally {
+          fs.closeSync(fd);
+        }
+      },
+    }, { port: args.port ?? 3000 });
+
+    process.on("SIGINT", async () => {
+      await dashboardHandle.close();
+      process.exit(0);
+    });
+    return;
+  }
+
   // Handle merge
   if (args.mode === "merge") {
     deps.logger.header(`${config.name} — Merge Mode`);

--- a/src/dashboard-html.ts
+++ b/src/dashboard-html.ts
@@ -1,0 +1,202 @@
+/**
+ * Renders a self-contained HTML dashboard page with inline CSS and JS.
+ * The page connects to /api/events via SSE for live status updates.
+ */
+export function renderDashboardHtml(name: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>${escapeHtml(name)} — Dashboard</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, monospace; background: #0d1117; color: #c9d1d9; padding: 24px; }
+  h1 { font-size: 1.4rem; margin-bottom: 16px; color: #f0f6fc; }
+  .summary { display: flex; gap: 16px; margin-bottom: 20px; font-size: 0.9rem; }
+  .summary .badge { padding: 4px 10px; border-radius: 4px; font-weight: 600; }
+  .succeeded { background: #1b4332; color: #2dd4bf; }
+  .failed { background: #4c1d1d; color: #f87171; }
+  .running { background: #3b2f00; color: #fbbf24; }
+  .pending-badge { background: #1e293b; color: #94a3b8; }
+  .skipped { background: #1e293b; color: #64748b; }
+
+  .waves { display: flex; gap: 24px; flex-wrap: wrap; align-items: flex-start; }
+  .wave { min-width: 260px; }
+  .wave h2 { font-size: 0.85rem; color: #8b949e; margin-bottom: 8px; text-transform: uppercase; letter-spacing: 0.05em; }
+
+  .card { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 12px; margin-bottom: 10px; transition: border-color 0.3s; }
+  .card.status-succeeded { border-left: 3px solid #2dd4bf; }
+  .card.status-failed { border-left: 3px solid #f87171; }
+  .card.status-running { border-left: 3px solid #fbbf24; }
+  .card.status-pending { border-left: 3px solid #30363d; }
+  .card.status-skipped { border-left: 3px solid #64748b; }
+  .card.status-interrupted { border-left: 3px solid #fb923c; }
+
+  .card-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 6px; }
+  .card-number { font-weight: 700; color: #58a6ff; }
+  .card-status { font-size: 0.75rem; padding: 2px 6px; border-radius: 3px; font-weight: 600; }
+  .card-desc { font-size: 0.85rem; color: #8b949e; margin-bottom: 6px; }
+  .card-meta { font-size: 0.75rem; color: #484f58; }
+  .card-meta a { color: #58a6ff; text-decoration: none; }
+  .card-meta a:hover { text-decoration: underline; }
+
+  .log-toggle { font-size: 0.75rem; color: #58a6ff; cursor: pointer; border: none; background: none; margin-top: 6px; }
+  .log-toggle:hover { text-decoration: underline; }
+  .log-content { display: none; margin-top: 8px; padding: 8px; background: #0d1117; border-radius: 4px; font-size: 0.75rem; white-space: pre-wrap; word-break: break-all; max-height: 200px; overflow-y: auto; color: #8b949e; }
+
+  .connected { color: #2dd4bf; }
+  .disconnected { color: #f87171; }
+  .conn-status { position: fixed; top: 12px; right: 24px; font-size: 0.75rem; }
+</style>
+</head>
+<body>
+<h1>${escapeHtml(name)}</h1>
+<div class="summary" id="summary"></div>
+<div class="conn-status" id="conn-status"></div>
+<div class="waves" id="waves"></div>
+
+<script>
+(function() {
+  let issues = [];
+  let config = {};
+  let statusMap = {};
+  let metadataMap = {};
+
+  function escHtml(s) { const d = document.createElement("div"); d.textContent = s; return d.innerHTML; }
+
+  function statusClass(s) {
+    return "status-" + (s || "pending");
+  }
+
+  function statusBadgeClass(s) {
+    if (s === "pending") return "pending-badge";
+    return s || "pending-badge";
+  }
+
+  function render() {
+    // Group by wave
+    const waves = {};
+    for (const issue of issues) {
+      const w = issue.wave || 1;
+      if (!waves[w]) waves[w] = [];
+      waves[w].push(issue);
+    }
+
+    // Summary counts
+    const counts = { succeeded: 0, failed: 0, running: 0, pending: 0, skipped: 0, interrupted: 0 };
+    for (const issue of issues) {
+      const s = statusMap[issue.number] || "pending";
+      counts[s] = (counts[s] || 0) + 1;
+    }
+
+    document.getElementById("summary").innerHTML =
+      '<span class="badge succeeded">Succeeded: ' + counts.succeeded + '</span>' +
+      '<span class="badge failed">Failed: ' + counts.failed + '</span>' +
+      '<span class="badge running">Running: ' + counts.running + '</span>' +
+      '<span class="badge pending-badge">Pending: ' + counts.pending + '</span>' +
+      '<span class="badge skipped">Skipped: ' + counts.skipped + '</span>' +
+      '<span>Total: ' + issues.length + '</span>';
+
+    const container = document.getElementById("waves");
+    container.innerHTML = "";
+
+    const sortedWaves = Object.keys(waves).map(Number).sort((a, b) => a - b);
+    for (const w of sortedWaves) {
+      const div = document.createElement("div");
+      div.className = "wave";
+      div.innerHTML = "<h2>Wave " + w + "</h2>";
+
+      for (const issue of waves[w]) {
+        const s = statusMap[issue.number] || "pending";
+        const meta = metadataMap[issue.number] || {};
+        const card = document.createElement("div");
+        card.className = "card " + statusClass(s);
+        card.id = "card-" + issue.number;
+
+        let metaHtml = "";
+        if (meta.prUrl) {
+          metaHtml += '<a href="' + escHtml(meta.prUrl) + '" target="_blank">PR</a> ';
+        }
+        if (meta.startedAt) {
+          metaHtml += "Started: " + new Date(meta.startedAt).toLocaleTimeString() + " ";
+        }
+        if (meta.retryCount) {
+          metaHtml += "Retries: " + meta.retryCount + " ";
+        }
+
+        card.innerHTML =
+          '<div class="card-header">' +
+            '<span class="card-number">#' + issue.number + ' ' + escHtml(issue.slug) + '</span>' +
+            '<span class="card-status ' + statusBadgeClass(s) + '">' + s.toUpperCase() + '</span>' +
+          '</div>' +
+          '<div class="card-desc">' + escHtml(issue.description) + '</div>' +
+          '<div class="card-meta">' + metaHtml + '</div>' +
+          '<button class="log-toggle" onclick="toggleLog(' + issue.number + ')">Show log</button>' +
+          '<pre class="log-content" id="log-' + issue.number + '"></pre>';
+
+        div.appendChild(card);
+      }
+      container.appendChild(div);
+    }
+  }
+
+  window.toggleLog = function(issueNumber) {
+    const el = document.getElementById("log-" + issueNumber);
+    if (!el) return;
+    if (el.style.display === "block") {
+      el.style.display = "none";
+      return;
+    }
+    el.style.display = "block";
+    el.textContent = "Loading...";
+    fetch("/api/logs/" + issueNumber)
+      .then(function(r) { return r.text(); })
+      .then(function(t) { el.textContent = t || "(no log output)"; })
+      .catch(function() { el.textContent = "(failed to load)"; });
+  };
+
+  // Initial load
+  fetch("/api/config")
+    .then(function(r) { return r.json(); })
+    .then(function(data) {
+      config = data;
+      issues = data.issues || [];
+      return fetch("/api/status");
+    })
+    .then(function(r) { return r.json(); })
+    .then(function(data) {
+      for (const entry of data) {
+        statusMap[entry.number] = entry.status;
+        metadataMap[entry.number] = entry.metadata || {};
+      }
+      render();
+    })
+    .catch(function(err) { console.error("Init failed:", err); });
+
+  // SSE
+  const connEl = document.getElementById("conn-status");
+  const es = new EventSource("/api/events");
+  es.onopen = function() { connEl.innerHTML = '<span class="connected">\\u25cf connected</span>'; };
+  es.onerror = function() { connEl.innerHTML = '<span class="disconnected">\\u25cf disconnected</span>'; };
+  es.addEventListener("status", function(e) {
+    const data = JSON.parse(e.data);
+    for (const entry of data) {
+      statusMap[entry.number] = entry.status;
+      if (entry.metadata) metadataMap[entry.number] = entry.metadata;
+    }
+    render();
+  });
+})();
+</script>
+</body>
+</html>`;
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}

--- a/src/dashboard-types.ts
+++ b/src/dashboard-types.ts
@@ -1,0 +1,25 @@
+import type { Issue, OrchestratorConfig, StatusStore, MetadataStore, Logger } from "./types.js";
+
+/** Dependencies for the dashboard server, injectable for testing. */
+export interface DashboardDeps {
+  statusStore: StatusStore;
+  metadataStore: MetadataStore;
+  config: OrchestratorConfig;
+  logger: Logger;
+  /** Read the last N bytes of a log file for an issue. */
+  readLogTail: (issueNumber: number, maxBytes: number) => string;
+}
+
+/** Options for creating the dashboard server. */
+export interface DashboardOptions {
+  port?: number;
+  host?: string;
+}
+
+/** Handle returned by createDashboardServer for lifecycle management. */
+export interface DashboardHandle {
+  /** The port the server is listening on. */
+  port: number;
+  /** Stop the server and clean up resources. */
+  close(): Promise<void>;
+}

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1,0 +1,158 @@
+import http from "node:http";
+import type { DashboardDeps, DashboardOptions, DashboardHandle } from "./dashboard-types.js";
+import { renderDashboardHtml } from "./dashboard-html.js";
+
+/**
+ * Create a read-only HTTP dashboard server with SSE-based live updates.
+ *
+ * Routes:
+ * - `GET /` — Single-page HTML dashboard
+ * - `GET /api/status` — JSON array of issue statuses with metadata
+ * - `GET /api/config` — JSON config (issues, waves, name)
+ * - `GET /api/logs/:issue` — Last 8KB of log file as text
+ * - `GET /api/metadata/:issue` — JSON metadata for an issue
+ * - `GET /api/events` — SSE endpoint, polls every 2s and emits on changes
+ */
+export function createDashboardServer(
+  deps: DashboardDeps,
+  options: DashboardOptions = {},
+): Promise<DashboardHandle> {
+  const { statusStore, metadataStore, config, logger, readLogTail } = deps;
+  const port = options.port ?? 3000;
+  const host = options.host ?? "127.0.0.1";
+
+  const sseClients = new Set<http.ServerResponse>();
+  const intervals = new Set<ReturnType<typeof setInterval>>();
+
+  function getStatusSnapshot(): Array<{ number: number; status: string; metadata: Record<string, unknown> }> {
+    return config.issues.map((issue) => ({
+      number: issue.number,
+      slug: issue.slug,
+      status: statusStore.get(issue.number),
+      metadata: metadataStore.get(issue.number),
+    }));
+  }
+
+  const htmlContent = renderDashboardHtml(config.name);
+
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url ?? "/", `http://${host}:${port}`);
+    const pathname = url.pathname;
+
+    // CORS headers for local dev
+    res.setHeader("Access-Control-Allow-Origin", "*");
+
+    if (pathname === "/" && req.method === "GET") {
+      res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+      res.end(htmlContent);
+      return;
+    }
+
+    if (pathname === "/api/status" && req.method === "GET") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(getStatusSnapshot()));
+      return;
+    }
+
+    if (pathname === "/api/config" && req.method === "GET") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({
+        name: config.name,
+        issues: config.issues.map((i) => ({
+          number: i.number,
+          slug: i.slug,
+          description: i.description,
+          wave: i.wave,
+          deps: i.deps,
+        })),
+      }));
+      return;
+    }
+
+    const logsMatch = pathname.match(/^\/api\/logs\/(\d+)$/);
+    if (logsMatch && req.method === "GET") {
+      const issueNumber = parseInt(logsMatch[1], 10);
+      try {
+        const logTail = readLogTail(issueNumber, 8192);
+        res.writeHead(200, { "Content-Type": "text/plain; charset=utf-8" });
+        res.end(logTail);
+      } catch {
+        res.writeHead(200, { "Content-Type": "text/plain; charset=utf-8" });
+        res.end("(no log output)");
+      }
+      return;
+    }
+
+    const metaMatch = pathname.match(/^\/api\/metadata\/(\d+)$/);
+    if (metaMatch && req.method === "GET") {
+      const issueNumber = parseInt(metaMatch[1], 10);
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(metadataStore.get(issueNumber)));
+      return;
+    }
+
+    if (pathname === "/api/events" && req.method === "GET") {
+      res.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        "Connection": "keep-alive",
+      });
+      res.write(":\n\n"); // SSE comment to establish connection
+
+      sseClients.add(res);
+
+      // Poll for changes every 2 seconds
+      let lastSnapshot = JSON.stringify(getStatusSnapshot());
+
+      const interval = setInterval(() => {
+        const current = JSON.stringify(getStatusSnapshot());
+        if (current !== lastSnapshot) {
+          lastSnapshot = current;
+          res.write(`event: status\ndata: ${current}\n\n`);
+        }
+      }, 2000);
+
+      intervals.add(interval);
+
+      req.on("close", () => {
+        clearInterval(interval);
+        intervals.delete(interval);
+        sseClients.delete(res);
+      });
+
+      return;
+    }
+
+    // 404 for unknown routes
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Not found" }));
+  });
+
+  return new Promise<DashboardHandle>((resolve, reject) => {
+    server.on("error", reject);
+    server.listen(port, host, () => {
+      logger.info(`Dashboard running at http://${host}:${port}`);
+      resolve({
+        port,
+        async close() {
+          // Clean up SSE intervals
+          for (const interval of intervals) {
+            clearInterval(interval);
+          }
+          intervals.clear();
+
+          // Close SSE connections
+          for (const client of sseClients) {
+            client.end();
+          }
+          sseClients.clear();
+
+          // Close server
+          return new Promise<void>((res, rej) => {
+            server.close((err) => (err ? rej(err) : res()));
+          });
+        },
+      });
+    });
+  });
+}

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -428,7 +428,8 @@ export class Orchestrator {
               return;
             }
 
-            if (!(await this.runPostSessionCheck(issue, worktreePath))) return;
+            const zeroRetryCheck = await this.runPostSessionCheck(issue, worktreePath);
+            if (!await this.handleCheckResultWithRetry(issue, zeroRetryCheck, prompt, worktreePath, logFile, stderrFile)) return;
 
             await this.setStatus(issue, "succeeded");
             this.deps.logger.info(
@@ -444,7 +445,8 @@ export class Orchestrator {
           return;
         }
 
-        if (!(await this.runPostSessionCheck(issue, worktreePath))) return;
+        const checkResult = await this.runPostSessionCheck(issue, worktreePath);
+        if (!await this.handleCheckResultWithRetry(issue, checkResult, prompt, worktreePath, logFile, stderrFile)) return;
 
         await this.setStatus(issue, "succeeded");
         this.deps.logger.info(`Issue #${issue.number} succeeded`);
@@ -465,28 +467,98 @@ export class Orchestrator {
   private async runPostSessionCheck(
     issue: Issue,
     worktreePath: string,
-  ): Promise<boolean> {
-    if (!this.config.hooks.postSessionCheck) return true;
+  ): Promise<import("./types.js").PostCheckResult> {
+    if (!this.config.hooks.postSessionCheck) return { passed: true };
 
     try {
       const result = await this.config.hooks.postSessionCheck(
         issue, worktreePath,
       );
       if (!result.passed) {
-        await this.setStatus(issue, "failed");
         this.deps.logger.error(
           `Issue #${issue.number} post-check failed: ${result.summary ?? "unknown reason"}`,
         );
-        return false;
       }
-      return true;
+      return result;
     } catch (err) {
-      await this.setStatus(issue, "failed");
+      const msg = err instanceof Error ? err.message : String(err);
       this.deps.logger.error(
-        `Issue #${issue.number} post-check threw: ${err instanceof Error ? err.message : String(err)}`,
+        `Issue #${issue.number} post-check threw: ${msg}`,
       );
+      return { passed: false, output: msg, summary: msg };
+    }
+  }
+
+  private async handleCheckResultWithRetry(
+    issue: Issue,
+    checkResult: import("./types.js").PostCheckResult,
+    originalPrompt: string,
+    worktreePath: string,
+    logFile: string,
+    stderrFile: string,
+  ): Promise<boolean> {
+    if (checkResult.passed) return true;
+
+    const retryConfig = this.config.retryOnCheckFailure;
+    if (!retryConfig?.enabled) {
+      await this.setStatus(issue, "failed");
       return false;
     }
+
+    const maxRetries = retryConfig.maxRetries;
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      this.deps.logger.warn(
+        `Issue #${issue.number} check failed, retry ${attempt}/${maxRetries}...`,
+      );
+
+      const failureContext = checkResult.output ?? checkResult.summary ?? "unknown failure";
+      const retryPrompt = `${originalPrompt}\n\n## CI Failure Context\n\nThe following checks failed:\n\n${failureContext}\n\nPlease fix these issues.`;
+
+      const tools = this.config.allowedTools ?? DEFAULT_ALLOWED_TOOLS;
+      const retryArgs = [
+        "-p", retryPrompt,
+        "--model", "opus",
+        "--allowedTools", tools.join(","),
+        ...this.config.hooks.getClaudeArgs(issue),
+        "--output-format", "stream-json",
+        "--verbose",
+      ];
+
+      const retryHandle = this.deps.processRunner.spawn(
+        "claude", retryArgs,
+        { cwd: worktreePath, logFile, stderrFile },
+      );
+
+      const retryExitCode = await retryHandle.exitCode;
+      this.deps.metadataStore.update(issue.number, {
+        exitCode: retryExitCode,
+        finishedAt: new Date().toISOString(),
+        retryCount: attempt,
+      });
+
+      if (retryExitCode !== 0) {
+        await this.setStatus(issue, "failed");
+        this.deps.logger.error(
+          `Issue #${issue.number} retry ${attempt} exited with code ${retryExitCode}`,
+        );
+        return false;
+      }
+
+      checkResult = await this.runPostSessionCheck(issue, worktreePath);
+      if (checkResult.passed) {
+        this.deps.logger.info(
+          `Issue #${issue.number} succeeded after retry ${attempt}`,
+        );
+        return true;
+      }
+    }
+
+    // All retries exhausted
+    await this.setStatus(issue, "failed");
+    this.deps.logger.error(
+      `Issue #${issue.number} failed after ${maxRetries} retries`,
+    );
+    return false;
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ export type {
   Status, IssueSpec, Issue, RawOrchestratorConfig, OrchestratorConfig,
   MergePolicy, RunOptions, PostCheckResult, OrchestratorHooks,
   ParsedMode, ParsedArgs, StatusStore, ProcessHandle, ProcessRunner,
-  Logger, IssueMetadata, MetadataStore, Deps, RunRecord, IssueCommentsConfig, LabelSyncConfig,
+  Logger, IssueMetadata, MetadataStore, Deps, RunRecord, IssueCommentsConfig, LabelSyncConfig, RetryOnCheckFailureConfig,
 } from "./types.js";
 
 // Engine

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,11 @@ export type { IssueCommentConfig, IssueCommentDeps } from "./issue-comments.js";
 export { createLabelSyncHandler } from "./label-sync.js";
 export type { LabelSyncHandlerConfig, LabelSyncDeps } from "./label-sync.js";
 
+// Dashboard
+export { createDashboardServer } from "./dashboard.js";
+export type { DashboardDeps, DashboardOptions, DashboardHandle } from "./dashboard-types.js";
+export { renderDashboardHtml } from "./dashboard-html.js";
+
 // GitHub integration
 export { addIssueLabel, removeIssueLabel, postIssueComment, ensureLabelExists } from "./github.js";
 export type { GitHubDeps, LabelOptions } from "./github.js";

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -24,6 +24,7 @@ const RawConfigSchema = z
     allowedTools: z.array(z.string()).optional(),
     issueComments: z.object({ repo: z.string(), enabled: z.boolean() }).optional(),
     labelSync: z.object({ prefix: z.string(), repo: z.string().optional() }).optional(),
+    retryOnCheckFailure: z.object({ maxRetries: z.number().int().positive(), enabled: z.boolean() }).optional(),
   })
   .check((ctx) => {
     const issues = ctx.value.issues;
@@ -116,5 +117,6 @@ export function validateConfig(raw: RawOrchestratorConfig): OrchestratorConfig {
     ...(parsed.allowedTools && { allowedTools: parsed.allowedTools }),
     ...(parsed.issueComments && { issueComments: parsed.issueComments }),
     ...(parsed.labelSync && { labelSync: parsed.labelSync }),
+    ...(parsed.retryOnCheckFailure && { retryOnCheckFailure: parsed.retryOnCheckFailure }),
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,6 +46,8 @@ export interface RawOrchestratorConfig {
   issueComments?: IssueCommentsConfig;
   /** Sync issue labels on status changes. */
   labelSync?: LabelSyncConfig;
+  /** Auto-retry when postSessionCheck fails. */
+  retryOnCheckFailure?: RetryOnCheckFailureConfig;
 }
 
 export interface OrchestratorConfig {
@@ -62,6 +64,8 @@ export interface OrchestratorConfig {
   issueComments?: IssueCommentsConfig;
   /** Sync issue labels on status changes. */
   labelSync?: LabelSyncConfig;
+  /** Auto-retry when postSessionCheck fails. */
+  retryOnCheckFailure?: RetryOnCheckFailureConfig;
 }
 
 export type MergePolicy = "none" | "after-wave";
@@ -73,7 +77,15 @@ export interface RunOptions {
 
 export interface PostCheckResult {
   passed: boolean;
+  /** Human-readable summary for logs. */
   summary?: string;
+  /** Raw command output for machine consumption (injected into retry prompts). */
+  output?: string;
+}
+
+export interface RetryOnCheckFailureConfig {
+  maxRetries: number;
+  enabled: boolean;
 }
 
 export interface OrchestratorHooks {
@@ -156,6 +168,7 @@ export interface IssueMetadata {
   startedAt?: string;
   finishedAt?: string;
   filesChanged?: string[];
+  retryCount?: number;
 }
 
 export interface MetadataStore {

--- a/src/types.ts
+++ b/src/types.ts
@@ -117,7 +117,8 @@ export type ParsedMode =
   | "tail"
   | "run-all"
   | "run-specific"
-  | "decompose";
+  | "decompose"
+  | "dashboard";
 
 export interface ParsedArgs {
   mode: ParsedMode;
@@ -131,6 +132,7 @@ export interface ParsedArgs {
   createIssues?: boolean;
   decomposeIssue?: number;
   decomposeRepo?: string;
+  port?: number;
 }
 
 export interface StatusStore {

--- a/src/yaml-hooks.ts
+++ b/src/yaml-hooks.ts
@@ -189,6 +189,7 @@ export function deriveHooks(
           return {
             passed: false,
             summary: `Command failed: ${cmd}\n${(err as Error).message}`,
+            output: (err as Error).message,
           };
         }
       }

--- a/src/yaml-loader.ts
+++ b/src/yaml-loader.ts
@@ -64,5 +64,6 @@ export async function loadYamlConfig(
     ...(yaml.allowedTools && { allowedTools: yaml.allowedTools }),
     ...(yaml.issueComments && { issueComments: { repo: yaml.issueComments.repo, enabled: yaml.issueComments.enabled ?? true } }),
     ...(yaml.labelSync && { labelSync: yaml.labelSync }),
+    ...(yaml.retryOnCheckFailure && { retryOnCheckFailure: { maxRetries: yaml.retryOnCheckFailure.maxRetries, enabled: yaml.retryOnCheckFailure.enabled ?? true } }),
   });
 }

--- a/src/yaml-schema.ts
+++ b/src/yaml-schema.ts
@@ -50,5 +50,6 @@ export const YamlConfigSchema = z.object({
   summary: YamlSummarySchema.optional(),
   issueComments: z.object({ repo: z.string(), enabled: z.boolean().optional() }).optional(),
   labelSync: z.object({ prefix: z.string(), repo: z.string().optional() }).optional(),
+  retryOnCheckFailure: z.object({ maxRetries: z.number().int().positive(), enabled: z.boolean().optional() }).optional(),
   issues: z.array(YamlIssueSchema),
 });

--- a/src/yaml-types.ts
+++ b/src/yaml-types.ts
@@ -58,6 +58,8 @@ export interface YamlConfig {
   issueComments?: { repo: string; enabled?: boolean };
   /** Sync issue labels on status changes. */
   labelSync?: { prefix: string; repo?: string };
+  /** Auto-retry when postSessionCheck fails. */
+  retryOnCheckFailure?: { maxRetries: number; enabled?: boolean };
   issues: YamlIssue[];
 }
 


### PR DESCRIPTION
## Summary

- Adds CI failure feedback loop: auto-retries agent sessions with failure context injected into the prompt when `postSessionCheck` fails (configurable via `retryOnCheckFailure`)
- Changes `runPostSessionCheck` to return full `PostCheckResult` (with `output` field) instead of boolean
- Adds read-only HTTP dashboard server (`src/dashboard.ts`) with SSE live updates using Node.js built-in `http` module (no new dependencies)
- Self-contained HTML page with inline CSS/JS showing issues grouped by wave with status badges, PR links, and expandable log tails
- Adds `--dashboard` and `--port` CLI flags
- Updates CLAUDE.md and README.md with all new features

Part 4 of 4 for #13. Stacked on #16. Closes #10, #11, #12.

## Test plan

- [x] `npm test` passes (all new + existing tests: 385 total)
- [x] `npm run typecheck` passes
- [ ] Verify CI retry re-spawns agent with failure context in prompt
- [ ] Verify max retries is respected
- [ ] Verify dashboard serves HTML, JSON APIs, and SSE events
- [ ] Verify `--dashboard --port 8080` starts server on custom port