### PR TITLE
feat: self-host orchestrator on this repo's open issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,7 @@ out
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 worklog/
+
+# Self-hosted orchestrator runtime state
+worktrees/
+.orchestrator/state/

--- a/.orchestrator/README.md
+++ b/.orchestrator/README.md
@@ -1,0 +1,86 @@
+# Self-hosted orchestrator
+
+This directory configures `claude-orchestrator` to run on its own open issues. It dogfoods the tool and lets multiple disjoint issues land in parallel.
+
+## Files
+
+| Path | Purpose |
+|---|---|
+| `config.yaml` | YAML config — fields documented in `CLAUDE.md` at the repo root. The `issues` array is filled in per wave. |
+| `hooks.ts` | `setUpWorktree` and `removeWorktree` overrides. Creates worktrees under `<repo>/worktrees/<slug>` and runs `npm ci` so the agent has working `npm test`/`typecheck`. |
+| `prompt.md` | Prompt template used for every issue. Pulls in `gh issue view` to read the canonical body, instructs TDD + local CI gate + `Closes #N` PR + no AI attribution. |
+| `run.ts` | Entry point. Imports orchestrator core from compiled `dist/`, hooks from local `./hooks.ts`. |
+| `state/` | Runtime state (status files, metadata, run history, counters). Gitignored. Recreated on each run. |
+
+## Prerequisites
+
+- Node 22+ (uses `--experimental-strip-types`).
+- `gh` CLI authenticated against `jakebromberg/claude-orchestrator`.
+- `dist/` built and committed at HEAD of `main` (the orchestrator imports from `dist/src/...`). Run `npm run build` after any source change before orchestrating.
+
+## Per-wave workflow
+
+1. Edit `config.yaml`. Set the `issues` array to the wave's issue numbers, slugs, dependencies, and descriptions. Existing GitHub issues already carry the description body — keep YAML descriptions short; the agent reads the full body via `gh issue view`.
+
+   ```yaml
+   issues:
+     - number: 41
+       slug: skip-status-propagation
+       dependsOn: []
+       description: "shouldSkipIssue should write succeeded status so dependents unblock."
+     - number: 35
+       slug: shell-quote-github-and-create-main
+       dependsOn: []
+       description: "Apply shellQuote to gh CLI invocations and osascript notification path."
+   ```
+
+2. Run the wave:
+
+   ```bash
+   npm run orchestrate -- --parallel 2
+   ```
+
+   Add `--detach` to background the run, `--notify` for a macOS notification on completion.
+
+3. Watch live:
+
+   ```bash
+   npm run orchestrate:dashboard
+   # then open http://localhost:3000
+   ```
+
+   Or use the terminal watch:
+
+   ```bash
+   npm run orchestrate -- --watch
+   ```
+
+4. After all issues succeed, merge via:
+
+   ```bash
+   npm run orchestrate -- --merge
+   ```
+
+   Or merge each PR manually via `gh pr merge --rebase`.
+
+5. Clean up worktrees and branches:
+
+   ```bash
+   npm run orchestrate:cleanup
+   ```
+
+## Recovery
+
+- A failed issue can be retried with `npm run orchestrate -- --retry-failed`.
+- A wave running in `--detach` mode can be reattached with `npm run orchestrate -- --tail`.
+- Status snapshots: `npm run orchestrate:status`.
+
+## Debugging a session
+
+Logs and stream-json transcripts go to `state/<config-name>/logs/issue-<N>.log`. The hook-events flag is on by default, so PreToolUse / PostToolUse decisions appear in the transcript for post-mortem analysis.
+
+## Caveats
+
+- Each worktree runs `npm ci` on setup (~30s). Two parallel issues = 1 minute of dependency-install overhead before agent work begins.
+- `dist/` must be in sync with `src/` at HEAD of `main`. If the orchestrator behaves oddly after a code change, run `npm run build` and commit before orchestrating.
+- Worktrees and `state/` are gitignored. Don't rely on their contents persisting across `--cleanup` runs.

--- a/.orchestrator/config.yaml
+++ b/.orchestrator/config.yaml
@@ -1,0 +1,30 @@
+name: "claude-orchestrator"
+configDir: "./state"
+worktreeDir: "../worktrees"
+projectRoot: ".."
+stallTimeout: 900
+promptTemplate: "./prompt.md"
+branchPrefix: "orchestrator/"
+baseBranch: "main"
+
+claudeArgs: ["--model", "sonnet"]
+
+postSessionCheck:
+  commands:
+    - "npm run typecheck"
+    - "npm test"
+
+retryOnCheckFailure:
+  maxRetries: 2
+
+issueComments:
+  repo: "jakebromberg/claude-orchestrator"
+  enabled: true
+
+labelSync:
+  prefix: "orchestrator"
+  repo: "jakebromberg/claude-orchestrator"
+
+# Issues are filled in per wave. Update this list before each orchestrator run.
+# See README at .orchestrator/README.md for the per-wave issue blocks.
+issues: []

--- a/.orchestrator/hooks.ts
+++ b/.orchestrator/hooks.ts
@@ -1,0 +1,74 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { HooksOverride } from "../dist/src/yaml-types.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, "..");
+
+function getWorktreePath(slug: string): string {
+  return resolve(REPO_ROOT, "worktrees", slug);
+}
+
+function getBranchName(slug: string): string {
+  return `orchestrator/${slug}`;
+}
+
+const hooksOverride: HooksOverride = {
+  getWorktreePath(issue) {
+    return getWorktreePath(issue.slug);
+  },
+
+  getBranchName(issue) {
+    return getBranchName(issue.slug);
+  },
+
+  async setUpWorktree(issue) {
+    const worktreePath = getWorktreePath(issue.slug);
+    const branch = getBranchName(issue.slug);
+
+    mkdirSync(resolve(worktreePath, ".."), { recursive: true });
+
+    if (!existsSync(worktreePath)) {
+      try {
+        execFileSync(
+          "git",
+          ["-C", REPO_ROOT, "worktree", "add", worktreePath, "-b", branch, "origin/main"],
+          { stdio: "pipe" },
+        );
+      } catch {
+        // Branch may already exist locally — try checking it out
+        execFileSync(
+          "git",
+          ["-C", REPO_ROOT, "worktree", "add", worktreePath, branch],
+          { stdio: "pipe" },
+        );
+      }
+    }
+
+    // Agent and postSessionCheck both need node_modules. `npm ci` is fast and
+    // deterministic given the lockfile is at HEAD of main.
+    execFileSync("npm", ["ci", "--no-audit", "--no-fund", "--prefer-offline"], {
+      cwd: worktreePath,
+      stdio: "pipe",
+    });
+  },
+
+  async removeWorktree(issue) {
+    const worktreePath = getWorktreePath(issue.slug);
+    if (existsSync(worktreePath)) {
+      try {
+        execFileSync(
+          "git",
+          ["-C", REPO_ROOT, "worktree", "remove", worktreePath, "--force"],
+          { stdio: "pipe" },
+        );
+      } catch {
+        // Best effort; operator can clean up manually if needed.
+      }
+    }
+  },
+};
+
+export default hooksOverride;

--- a/.orchestrator/prompt.md
+++ b/.orchestrator/prompt.md
@@ -1,0 +1,93 @@
+# claude-orchestrator — Issue #{{ISSUE_NUMBER}}: {{SLUG}}
+
+You are a software engineer working on `claude-orchestrator`, a TypeScript engine for launching parallel headless Claude sessions against GitHub issues. Your task is to implement the change for issue #{{ISSUE_NUMBER}} end-to-end: code, tests, commit, push, and open a pull request.
+
+## Working directory
+
+You are in a fresh git worktree checked out at `orchestrator/{{SLUG}}` from `origin/main`. Dependencies are already installed (`npm ci` ran during worktree setup). The full project tree is here, including `dist/`, `src/`, `__tests__/`, and `CLAUDE.md`.
+
+Repository: `jakebromberg/claude-orchestrator`. Base branch: `main`.
+
+## Task
+
+{{DESCRIPTION}}
+
+Read the full issue body before you start:
+
+```
+gh issue view {{ISSUE_NUMBER}}
+```
+
+The issue body contains the canonical problem statement, suggested shapes, code references, and acceptance criteria. Treat it as authoritative.
+
+## Upstream context
+
+{{UPSTREAM_CONTEXT}}
+
+## How to work
+
+1. **Read `CLAUDE.md`** at the repo root before touching code. It documents the module structure, key patterns (dependency injection, in-memory testing, wave scheduling, hook event auditing, sequential-file collision detection), and conventions you must follow.
+2. **TDD**: write a failing test first, then the implementation, then a passing test. Refactor when something repeats. Parameterize tests when natural. Existing tests live in `__tests__/`; mirror their patterns (vitest, `InMemoryStatusStore`, `InMemoryMetadataStore`, `createSilentLogger`, mock `ProcessRunner`).
+3. **Match existing style.** Read neighboring files in the same module before introducing a new pattern. Use `path` and `fs` from `node:` imports. Use `.js` extensions in `src/` imports per the project's Node16 module resolution.
+4. **Type safety.** Run `npm run typecheck` after each code edit. Fix type errors immediately rather than letting them accumulate.
+5. **Local CI gate.** Before pushing, both of these must pass:
+   ```
+   npm run typecheck
+   npm test
+   ```
+   If a test fails, fix the underlying issue. Do not skip, mark `.todo`, or weaken assertions.
+
+## Committing
+
+- Use `git mv` for renames so history is preserved.
+- Prefer rebasing over merging.
+- Never use `--no-verify` or skip hooks.
+- Commit messages: short imperative subject, concise body explaining the *why*. Do not mention Claude, Claude Code, or AI assistance anywhere — no Co-Authored-By lines, no attribution, no comments referencing the assistant.
+
+## Pull request
+
+When the implementation is complete and the local CI gate passes:
+
+1. Push the branch:
+   ```
+   git push -u origin orchestrator/{{SLUG}}
+   ```
+2. Open the PR:
+   ```
+   gh pr create --title "<short imperative title>" --body "$(cat <<'EOF'
+   ## Summary
+   <1–3 bullets describing the change>
+
+   ## Test plan
+   - [ ] <how to verify>
+
+   Closes #{{ISSUE_NUMBER}}
+   EOF
+   )"
+   ```
+3. The `Closes #{{ISSUE_NUMBER}}` line is required — it auto-closes the issue on merge.
+4. Do not mention Claude or Claude Code in the title, body, or anywhere else.
+5. After the PR opens, watch CI:
+   ```
+   gh run watch <run-id> --exit-status
+   ```
+   Fix any failures before considering your work done.
+
+## Handoff for downstream issues
+
+If another issue depends on yours, write a `HANDOFF.md` at the worktree root summarizing:
+1. What you changed (files, key functions, public surface).
+2. Any decisions or contracts the next issue should know about (new YAML fields, type signatures, behavior guarantees).
+3. Caveats — known sharp edges, follow-up TODOs, things you intentionally left for later.
+
+The orchestrator reads `HANDOFF.md` from upstream worktrees and injects the content into downstream prompts via `{{UPSTREAM_CONTEXT}}`.
+
+## Definition of done
+
+- All acceptance criteria from the issue body are met.
+- `npm run typecheck` and `npm test` pass locally.
+- Code follows the patterns in `CLAUDE.md` and adjacent files.
+- Tests cover the new behavior, including failure modes where relevant.
+- A pull request is open with `Closes #{{ISSUE_NUMBER}}` in the body.
+- `HANDOFF.md` is written if a downstream issue depends on this one.
+- No Claude / Claude Code attribution anywhere in code, comments, commits, or PR text.

--- a/.orchestrator/run.ts
+++ b/.orchestrator/run.ts
@@ -1,0 +1,14 @@
+import path from "node:path";
+import { createMain } from "../dist/src/index.js";
+import { loadYamlConfig } from "../dist/src/yaml-loader.js";
+import hooksOverride from "./hooks.ts";
+
+const configPath = path.resolve(import.meta.dirname, "config.yaml");
+
+createMain({
+  configs: {
+    "claude-orchestrator": async () =>
+      loadYamlConfig(configPath, { hooksOverride }),
+  },
+  projectRoot: path.resolve(import.meta.dirname, ".."),
+});

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,3 +156,16 @@ npm test           # Run tests
 npm run typecheck  # Type-check
 npm run build      # Build to dist/
 ```
+
+### Self-hosted orchestration
+
+This repo orchestrates work on its own open issues via `.orchestrator/`. See `.orchestrator/README.md` for the per-wave workflow.
+
+```bash
+npm run orchestrate           # Run a wave (configure issues in .orchestrator/config.yaml first)
+npm run orchestrate:status    # Show current issue statuses
+npm run orchestrate:dashboard # HTTP dashboard at :3000
+npm run orchestrate:cleanup   # Remove worktrees and branches
+```
+
+`.orchestrator/run.ts` imports the orchestrator core from `dist/`, so `npm run build` must be up-to-date before running.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,11 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "orchestrate": "node --experimental-strip-types --no-warnings=ExperimentalWarning .orchestrator/run.ts claude-orchestrator",
+    "orchestrate:status": "node --experimental-strip-types --no-warnings=ExperimentalWarning .orchestrator/run.ts claude-orchestrator --status",
+    "orchestrate:dashboard": "node --experimental-strip-types --no-warnings=ExperimentalWarning .orchestrator/run.ts claude-orchestrator --dashboard",
+    "orchestrate:cleanup": "node --experimental-strip-types --no-warnings=ExperimentalWarning .orchestrator/run.ts claude-orchestrator --cleanup"
   },
   "keywords": [
     "claude",


### PR DESCRIPTION
## Summary

- Adds `.orchestrator/` scaffold (`config.yaml`, `hooks.ts`, `prompt.md`, `run.ts`, `README.md`) so this repo can run claude-orchestrator on its own GitHub issues.
- Worktrees go to `<repo>/worktrees/<slug>` (gitignored). `setUpWorktree` creates the worktree from `origin/main` and runs `npm ci` so the agent has working `npm test` / `typecheck`.
- npm scripts: `orchestrate`, `orchestrate:status`, `orchestrate:dashboard`, `orchestrate:cleanup`. Entry runs via Node 22+ `--experimental-strip-types`; orchestrator core is imported from the committed `dist/`.

## Test plan

- [x] `npm run typecheck` passes.
- [x] `npm test` passes (503/503).
- [x] `npm run orchestrate:status` loads the YAML and prints the status table.
- [ ] First real wave (#41 + #35) lands successfully via `npm run orchestrate -- --parallel 2`.

Closes #42