### PR TITLE
feat: apply shellQuote to github.ts and create-main.ts

### DIFF
--- a/__tests__/create-main.test.ts
+++ b/__tests__/create-main.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildGhIssueCreateCommand,
+  buildNotificationScript,
+} from "../src/create-main.js";
+
+describe("buildGhIssueCreateCommand", () => {
+  it("produces a well-formed gh issue create command", () => {
+    expect(buildGhIssueCreateCommand("owner/repo", "my-feature")).toBe(
+      "gh issue create --repo 'owner/repo' --title 'my-feature' --body-file -",
+    );
+  });
+
+  it("shell-quotes repo with spaces", () => {
+    expect(buildGhIssueCreateCommand("owner/my repo", "slug")).toBe(
+      "gh issue create --repo 'owner/my repo' --title 'slug' --body-file -",
+    );
+  });
+
+  it("shell-quotes title containing single quote", () => {
+    expect(buildGhIssueCreateCommand("owner/repo", "Jake's feature")).toBe(
+      "gh issue create --repo 'owner/repo' --title 'Jake'\\''s feature' --body-file -",
+    );
+  });
+
+  it("shell-quotes title containing dollar sign and backtick", () => {
+    expect(buildGhIssueCreateCommand("owner/repo", "$title`name`")).toBe(
+      "gh issue create --repo 'owner/repo' --title '$title`name`' --body-file -",
+    );
+  });
+});
+
+describe("buildNotificationScript", () => {
+  it("produces valid AppleScript for a plain name", () => {
+    expect(buildNotificationScript("My Project", "3 succeeded, 1 failed")).toBe(
+      'display notification "3 succeeded, 1 failed" with title "My Project"',
+    );
+  });
+
+  it("escapes double quotes in name using AppleScript string concatenation", () => {
+    expect(buildNotificationScript('Project "X"', "1 succeeded, 0 failed")).toBe(
+      'display notification "1 succeeded, 0 failed" with title "Project " & quote & "X" & quote & ""',
+    );
+  });
+
+  it("passes single quotes, dollar signs, and backticks through unchanged", () => {
+    // These are safe because execFileSync passes args without shell expansion.
+    expect(buildNotificationScript("Jake's $project`s`", "2 succeeded, 0 failed")).toBe(
+      "display notification \"2 succeeded, 0 failed\" with title \"Jake's $project`s`\"",
+    );
+  });
+
+  it("handles name with only special characters", () => {
+    expect(buildNotificationScript("$`'", "0 succeeded, 1 failed")).toBe(
+      "display notification \"0 succeeded, 1 failed\" with title \"$`'\"",
+    );
+  });
+});

--- a/__tests__/github.test.ts
+++ b/__tests__/github.test.ts
@@ -137,7 +137,7 @@ describe("ensureLabelExists", () => {
     const deps = makeDeps();
     ensureLabelExists("owner/repo", "bug", deps, { color: "d73a4a" });
     expect(deps.runCommand).toHaveBeenCalledWith(
-      "gh label create 'bug' --repo 'owner/repo' --force --color d73a4a",
+      "gh label create 'bug' --repo 'owner/repo' --force --color 'd73a4a'",
     );
   });
 

--- a/__tests__/github.test.ts
+++ b/__tests__/github.test.ts
@@ -21,15 +21,47 @@ describe("addIssueLabel", () => {
     const deps = makeDeps();
     addIssueLabel("owner/repo", 42, "bug", deps);
     expect(deps.runCommand).toHaveBeenCalledWith(
-      'gh issue edit 42 --repo owner/repo --add-label "bug"',
+      "gh issue edit 42 --repo 'owner/repo' --add-label 'bug'",
     );
   });
 
-  it("escapes label with quotes", () => {
+  it("shell-quotes label with colon", () => {
     const deps = makeDeps();
     addIssueLabel("owner/repo", 1, "status:running", deps);
     expect(deps.runCommand).toHaveBeenCalledWith(
-      'gh issue edit 1 --repo owner/repo --add-label "status:running"',
+      "gh issue edit 1 --repo 'owner/repo' --add-label 'status:running'",
+    );
+  });
+
+  it("shell-quotes label containing spaces", () => {
+    const deps = makeDeps();
+    addIssueLabel("owner/repo", 1, "needs review", deps);
+    expect(deps.runCommand).toHaveBeenCalledWith(
+      "gh issue edit 1 --repo 'owner/repo' --add-label 'needs review'",
+    );
+  });
+
+  it("shell-quotes label containing single quote", () => {
+    const deps = makeDeps();
+    addIssueLabel("owner/repo", 1, "Jake's label", deps);
+    expect(deps.runCommand).toHaveBeenCalledWith(
+      "gh issue edit 1 --repo 'owner/repo' --add-label 'Jake'\\''s label'",
+    );
+  });
+
+  it("shell-quotes label containing dollar sign and backtick", () => {
+    const deps = makeDeps();
+    addIssueLabel("owner/repo", 1, "$label`name`", deps);
+    expect(deps.runCommand).toHaveBeenCalledWith(
+      "gh issue edit 1 --repo 'owner/repo' --add-label '$label`name`'",
+    );
+  });
+
+  it("shell-quotes repo containing spaces", () => {
+    const deps = makeDeps();
+    addIssueLabel("owner/my repo", 1, "bug", deps);
+    expect(deps.runCommand).toHaveBeenCalledWith(
+      "gh issue edit 1 --repo 'owner/my repo' --add-label 'bug'",
     );
   });
 });
@@ -39,7 +71,15 @@ describe("removeIssueLabel", () => {
     const deps = makeDeps();
     removeIssueLabel("owner/repo", 42, "bug", deps);
     expect(deps.runCommand).toHaveBeenCalledWith(
-      'gh issue edit 42 --repo owner/repo --remove-label "bug"',
+      "gh issue edit 42 --repo 'owner/repo' --remove-label 'bug'",
+    );
+  });
+
+  it("shell-quotes label and repo with shell metacharacters", () => {
+    const deps = makeDeps();
+    removeIssueLabel("owner/repo", 1, "$bad`label", deps);
+    expect(deps.runCommand).toHaveBeenCalledWith(
+      "gh issue edit 1 --repo 'owner/repo' --remove-label '$bad`label'",
     );
   });
 });
@@ -49,7 +89,7 @@ describe("postIssueComment", () => {
     const deps = makeDeps();
     postIssueComment("owner/repo", 42, "Hello world", deps);
     expect(deps.runCommand).toHaveBeenCalledWith(
-      "gh issue comment 42 --repo owner/repo --body-file -",
+      "gh issue comment 42 --repo 'owner/repo' --body-file -",
       { input: "Hello world" },
     );
   });
@@ -59,7 +99,7 @@ describe("postIssueComment", () => {
     const body = "## Status\n\n- [x] Done\n- [ ] Pending\n\n> Quote with `code`";
     postIssueComment("owner/repo", 1, body, deps);
     expect(deps.runCommand).toHaveBeenCalledWith(
-      "gh issue comment 1 --repo owner/repo --body-file -",
+      "gh issue comment 1 --repo 'owner/repo' --body-file -",
       { input: body },
     );
   });
@@ -69,8 +109,17 @@ describe("postIssueComment", () => {
     const body = 'Body with "quotes" and $variables and `backticks`';
     postIssueComment("owner/repo", 1, body, deps);
     expect(deps.runCommand).toHaveBeenCalledWith(
-      "gh issue comment 1 --repo owner/repo --body-file -",
+      "gh issue comment 1 --repo 'owner/repo' --body-file -",
       { input: body },
+    );
+  });
+
+  it("shell-quotes repo with spaces and metacharacters", () => {
+    const deps = makeDeps();
+    postIssueComment("owner/my repo", 1, "body", deps);
+    expect(deps.runCommand).toHaveBeenCalledWith(
+      "gh issue comment 1 --repo 'owner/my repo' --body-file -",
+      { input: "body" },
     );
   });
 });
@@ -80,7 +129,7 @@ describe("ensureLabelExists", () => {
     const deps = makeDeps();
     ensureLabelExists("owner/repo", "status:running", deps);
     expect(deps.runCommand).toHaveBeenCalledWith(
-      'gh label create "status:running" --repo owner/repo --force',
+      "gh label create 'status:running' --repo 'owner/repo' --force",
     );
   });
 
@@ -88,7 +137,7 @@ describe("ensureLabelExists", () => {
     const deps = makeDeps();
     ensureLabelExists("owner/repo", "bug", deps, { color: "d73a4a" });
     expect(deps.runCommand).toHaveBeenCalledWith(
-      'gh label create "bug" --repo owner/repo --force --color d73a4a',
+      "gh label create 'bug' --repo 'owner/repo' --force --color d73a4a",
     );
   });
 
@@ -98,7 +147,33 @@ describe("ensureLabelExists", () => {
       description: "Something isn't working",
     });
     expect(deps.runCommand).toHaveBeenCalledWith(
-      "gh label create \"bug\" --repo owner/repo --force --description \"Something isn\\'t working\"",
+      "gh label create 'bug' --repo 'owner/repo' --force --description 'Something isn'\\''t working'",
+    );
+  });
+
+  it("shell-quotes label and repo with spaces", () => {
+    const deps = makeDeps();
+    ensureLabelExists("owner/my repo", "needs review", deps);
+    expect(deps.runCommand).toHaveBeenCalledWith(
+      "gh label create 'needs review' --repo 'owner/my repo' --force",
+    );
+  });
+
+  it("shell-quotes label containing dollar sign and backtick", () => {
+    const deps = makeDeps();
+    ensureLabelExists("owner/repo", "$meta`label", deps);
+    expect(deps.runCommand).toHaveBeenCalledWith(
+      "gh label create '$meta`label' --repo 'owner/repo' --force",
+    );
+  });
+
+  it("shell-quotes description with dollar sign", () => {
+    const deps = makeDeps();
+    ensureLabelExists("owner/repo", "bug", deps, {
+      description: "costs $5 per unit",
+    });
+    expect(deps.runCommand).toHaveBeenCalledWith(
+      "gh label create 'bug' --repo 'owner/repo' --force --description 'costs $5 per unit'",
     );
   });
 });

--- a/__tests__/label-sync.test.ts
+++ b/__tests__/label-sync.test.ts
@@ -45,7 +45,7 @@ describe("createLabelSyncHandler", () => {
 
     // Should add running label (pending is not synced, so no remove)
     expect(deps.runCommand).toHaveBeenCalledWith(
-      'gh issue edit 42 --repo owner/repo --add-label "orchestrator:running"',
+      "gh issue edit 42 --repo 'owner/repo' --add-label 'orchestrator:running'",
     );
   });
 
@@ -60,10 +60,10 @@ describe("createLabelSyncHandler", () => {
     await handler(issue, "running", "succeeded");
 
     expect(deps.runCommand).toHaveBeenCalledWith(
-      'gh issue edit 1 --repo owner/repo --remove-label "status:running"',
+      "gh issue edit 1 --repo 'owner/repo' --remove-label 'status:running'",
     );
     expect(deps.runCommand).toHaveBeenCalledWith(
-      'gh issue edit 1 --repo owner/repo --add-label "status:succeeded"',
+      "gh issue edit 1 --repo 'owner/repo' --add-label 'status:succeeded'",
     );
   });
 
@@ -78,10 +78,10 @@ describe("createLabelSyncHandler", () => {
     await handler(issue, "running", "failed");
 
     expect(deps.runCommand).toHaveBeenCalledWith(
-      'gh issue edit 5 --repo owner/repo --remove-label "ci:running"',
+      "gh issue edit 5 --repo 'owner/repo' --remove-label 'ci:running'",
     );
     expect(deps.runCommand).toHaveBeenCalledWith(
-      'gh issue edit 5 --repo owner/repo --add-label "ci:failed"',
+      "gh issue edit 5 --repo 'owner/repo' --add-label 'ci:failed'",
     );
   });
 
@@ -134,7 +134,7 @@ describe("createLabelSyncHandler", () => {
     await handler(issue, "pending", "running");
 
     expect(deps.runCommand).toHaveBeenCalledWith(
-      'gh issue edit 1 --repo other/repo --add-label "orchestrator:running"',
+      "gh issue edit 1 --repo 'other/repo' --add-label 'orchestrator:running'",
     );
   });
 
@@ -147,13 +147,13 @@ describe("createLabelSyncHandler", () => {
 
     // Should have called ensureLabelExists for running, succeeded, failed
     expect(deps.runCommand).toHaveBeenCalledWith(
-      expect.stringContaining('gh label create "orchestrator:running"'),
+      expect.stringContaining("gh label create 'orchestrator:running'"),
     );
     expect(deps.runCommand).toHaveBeenCalledWith(
-      expect.stringContaining('gh label create "orchestrator:succeeded"'),
+      expect.stringContaining("gh label create 'orchestrator:succeeded'"),
     );
     expect(deps.runCommand).toHaveBeenCalledWith(
-      expect.stringContaining('gh label create "orchestrator:failed"'),
+      expect.stringContaining("gh label create 'orchestrator:failed'"),
     );
   });
 });

--- a/src/create-main.ts
+++ b/src/create-main.ts
@@ -1,4 +1,4 @@
-import { execSync, spawn } from "node:child_process";
+import { execSync, execFileSync, spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { parseArgs } from "./cli.js";
@@ -13,10 +13,28 @@ import { startWatch } from "./watch.js";
 import { mergePrs } from "./merge.js";
 import { generateReport, formatReport } from "./report.js";
 import { postRunSummaryComments } from "./issue-comments.js";
+import { shellQuote } from "./shell-quote.js";
 
 export type ConfigFactory =
   | ((projectRoot: string) => OrchestratorConfig)
   | ((projectRoot: string) => Promise<OrchestratorConfig>);
+
+/** Exported for testing. Builds the `gh issue create` command string with shell-safe quoting. */
+export function buildGhIssueCreateCommand(repo: string, title: string): string {
+  return `gh issue create --repo ${shellQuote(repo)} --title ${shellQuote(title)} --body-file -`;
+}
+
+/**
+ * Exported for testing. Builds the AppleScript string for a macOS notification.
+ *
+ * Uses AppleScript string concatenation with `quote` to handle embedded double
+ * quotes in `name`. All other shell metacharacters are safe because the caller
+ * passes this string directly to `execFileSync` (no shell expansion).
+ */
+export function buildNotificationScript(name: string, message: string): string {
+  const safeTitle = name.replace(/"/g, '" & quote & "');
+  return `display notification "${message}" with title "${safeTitle}"`;
+}
 
 export interface MainOptions {
   configs: Record<string, ConfigFactory>;
@@ -33,7 +51,7 @@ function createRealDeps(config: OrchestratorConfig): Deps {
     generateSessionId: () => randomUUID(),
     commandExists: (cmd: string) => {
       try {
-        execSync(`command -v ${cmd}`, { stdio: "pipe" });
+        execSync(`command -v ${shellQuote(cmd)}`, { stdio: "pipe" });
         return true;
       } catch {
         return false;
@@ -126,7 +144,7 @@ export async function createMain(options: MainOptions): Promise<void> {
 
         const body = issue.description + (depRefs ? `\n\nDepends on: ${depRefs}` : "");
         const output = execSync(
-          `gh issue create --repo ${args.decomposeRepo} --title "${issue.slug}" --body-file -`,
+          buildGhIssueCreateCommand(args.decomposeRepo, issue.slug),
           { input: body, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] },
         );
         const match = output.match(/\/issues\/(\d+)/);
@@ -414,11 +432,8 @@ export async function createMain(options: MainOptions): Promise<void> {
         (i) => deps.statusStore.get(i.number) === "failed",
       ).length;
       const message = `${succeeded} succeeded, ${failed} failed`;
-      const title = config.name.replace(/"/g, '\\"');
       try {
-        execSync(
-          `osascript -e 'display notification "${message}" with title "${title}"'`,
-        );
+        execFileSync("osascript", ["-e", buildNotificationScript(config.name, message)]);
       } catch {
         // Non-fatal: osascript can fail in SSH sessions
       }

--- a/src/github.ts
+++ b/src/github.ts
@@ -74,7 +74,7 @@ export function ensureLabelExists(
 ): void {
   let cmd = `gh label create ${shellQuote(label)} --repo ${shellQuote(repo)} --force`;
   if (options?.color) {
-    cmd += ` --color ${options.color}`;
+    cmd += ` --color ${shellQuote(options.color)}`;
   }
   if (options?.description) {
     cmd += ` --description ${shellQuote(options.description)}`;

--- a/src/github.ts
+++ b/src/github.ts
@@ -5,6 +5,8 @@
  * All functions accept a `GitHubDeps` interface for dependency injection.
  */
 
+import { shellQuote } from "./shell-quote.js";
+
 /** Dependencies for GitHub operations, injectable for testing. */
 export interface GitHubDeps {
   runCommand: (cmd: string, options?: { input?: string }) => string;
@@ -24,7 +26,7 @@ export function addIssueLabel(
   deps: GitHubDeps,
 ): void {
   deps.runCommand(
-    `gh issue edit ${issueNumber} --repo ${repo} --add-label "${label}"`,
+    `gh issue edit ${issueNumber} --repo ${shellQuote(repo)} --add-label ${shellQuote(label)}`,
   );
 }
 
@@ -36,7 +38,7 @@ export function removeIssueLabel(
   deps: GitHubDeps,
 ): void {
   deps.runCommand(
-    `gh issue edit ${issueNumber} --repo ${repo} --remove-label "${label}"`,
+    `gh issue edit ${issueNumber} --repo ${shellQuote(repo)} --remove-label ${shellQuote(label)}`,
   );
 }
 
@@ -53,7 +55,7 @@ export function postIssueComment(
   deps: GitHubDeps,
 ): void {
   deps.runCommand(
-    `gh issue comment ${issueNumber} --repo ${repo} --body-file -`,
+    `gh issue comment ${issueNumber} --repo ${shellQuote(repo)} --body-file -`,
     { input: body },
   );
 }
@@ -70,13 +72,12 @@ export function ensureLabelExists(
   deps: GitHubDeps,
   options?: LabelOptions,
 ): void {
-  let cmd = `gh label create "${label}" --repo ${repo} --force`;
+  let cmd = `gh label create ${shellQuote(label)} --repo ${shellQuote(repo)} --force`;
   if (options?.color) {
     cmd += ` --color ${options.color}`;
   }
   if (options?.description) {
-    const escaped = options.description.replace(/'/g, "\\'");
-    cmd += ` --description "${escaped}"`;
+    cmd += ` --description ${shellQuote(options.description)}`;
   }
   deps.runCommand(cmd);
 }


### PR DESCRIPTION
## Summary

- Shell-quote all config-derived values interpolated into `gh` CLI commands in `src/github.ts` (repo, label, color, and description across five sites)
- In `src/create-main.ts`, shell-quote `cmd` in `commandExists` and repo/title in `gh issue create`; replace the `osascript execSync` call with `execFileSync` to bypass the shell entirely, and handle embedded `"` in config names via AppleScript `quote` concatenation
- Update `github.test.ts` and `label-sync.test.ts` to the new single-quoted command format; add parameterised tests for spaces, single quotes, backticks, and `$`; add `create-main.test.ts` covering the two extracted helper functions

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` passes (520 tests)
- [ ] Manual: verify a config with a name containing a single quote sends a macOS notification correctly (requires Darwin)

Closes #35