### PR TITLE
feat: add journal-aware merge driver for append-only JSON array files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,8 @@ src/
 ├── dashboard.ts          # HTTP dashboard server with SSE
 ├── dashboard-types.ts    # Dashboard dependency/option types
 ├── dashboard-html.ts     # Self-contained HTML template
+├── merge-appendable.ts   # Pure merge logic for append-only JSON array files
+├── cli-merge-appendable.ts # claude-orchestrator-merge-appendable CLI (git driver + manual resolve)
 ├── index.ts              # Public API barrel export
 └── testing.ts            # Test utility exports
 ```
@@ -62,6 +64,7 @@ src/
 - **CI retry**: When `retryOnCheckFailure` is configured, failed `postSessionCheck` results trigger automatic re-runs with failure context injected into the prompt.
 - **Hook event auditing**: `--include-hook-events` is passed by default so PreToolUse/PostToolUse hook decisions appear in the stream-json log for post-session analysis.
 - **Sequential-file collision detection**: When `sequentialPaths` is configured, `postSessionCheck` scans peer worktrees and `origin/<baseBranch>` for files added with the same captured key (e.g. Drizzle migration `NNNN_*.sql`) and fails the session on overlap. Failure context names the colliding peer/file and a suggested next-safe number, suitable for `retryOnCheckFailure` injection.
+- **Journal-aware merge driver**: When `appendableFiles` is configured, the `claude-orchestrator-merge-appendable` CLI can be wired as a git merge driver via `.gitattributes`. It merges append-only JSON arrays by a `keyField` (e.g. Drizzle `_journal.json` by `idx`), eliminating manual conflict resolution after parallel migrations. Supports git driver mode (`--base %O --current %A --incoming %B`) and manual post-conflict mode (`--resolve <file>`).
 - **Sequential-number coordination (`claimSequentialNumber`)**: When `sequentialDomains` is configured, the orchestrator exposes a `{{CLAIM_NUMBER}}` prompt variable that resolves to a partial CLI command (`node cli-claim.js --config <yaml> --issue <n> --domain`). Agents append a domain name and invoke the helper to receive a guaranteed-unique zero-padded number. State persists to `<configDir>/counters/<domain>.json` with a lockfile for cross-process safety. Claims are idempotent per `(domain, issueNumber)` so retries reuse the same number. First claim per domain seeds from `origin/<baseBranch>`. Composes with `sequentialPaths` (claim is primary synchronization, detection is the backstop).
 
 ### YAML Config Fields
@@ -111,6 +114,14 @@ sequentialDomains:
       - dir: "shared/database/src/migrations"
         pattern: "(\\d{4})_.*\\.sql"
     width: 4
+
+# Append-style JSON array files wired to the journal-aware merge driver (issue #37).
+# Prevents merge conflicts on files like Drizzle's _journal.json.
+appendableFiles:
+  - path: "shared/database/src/migrations/meta/_journal.json"
+    format: "json-array"
+    arrayPath: "entries"
+    keyField: "idx"
 
 # Template variables: {{ISSUE_NUMBER}}, {{SLUG}}, {{DESCRIPTION}},
 # {{projectRoot}}, {{configDir}}, {{worktreeDir}}, {{UPSTREAM_CONTEXT}},

--- a/__tests__/cli-merge-appendable.test.ts
+++ b/__tests__/cli-merge-appendable.test.ts
@@ -1,0 +1,265 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+import {
+  parseMergeAppendableArgs,
+  runMergeDriver,
+} from "../src/cli-merge-appendable.js";
+
+// ---------------------------------------------------------------------------
+// parseMergeAppendableArgs — git driver mode
+// ---------------------------------------------------------------------------
+
+describe("parseMergeAppendableArgs — driver mode", () => {
+  it("parses all required driver flags inline", () => {
+    const args = parseMergeAppendableArgs([
+      "--base", "/tmp/base.json",
+      "--current", "/tmp/current.json",
+      "--incoming", "/tmp/incoming.json",
+      "--array-path", "entries",
+      "--key-field", "idx",
+    ]);
+    expect(args).toEqual({
+      mode: "driver",
+      base: "/tmp/base.json",
+      current: "/tmp/current.json",
+      incoming: "/tmp/incoming.json",
+      arrayPath: "entries",
+      keyField: "idx",
+    });
+  });
+
+  it("throws when --base is missing", () => {
+    expect(() =>
+      parseMergeAppendableArgs([
+        "--current", "/tmp/cur.json",
+        "--incoming", "/tmp/inc.json",
+        "--array-path", "entries",
+        "--key-field", "idx",
+      ]),
+    ).toThrow(/--base/);
+  });
+
+  it("throws when --current is missing", () => {
+    expect(() =>
+      parseMergeAppendableArgs([
+        "--base", "/tmp/base.json",
+        "--incoming", "/tmp/inc.json",
+        "--array-path", "entries",
+        "--key-field", "idx",
+      ]),
+    ).toThrow(/--current/);
+  });
+
+  it("throws when --incoming is missing", () => {
+    expect(() =>
+      parseMergeAppendableArgs([
+        "--base", "/tmp/base.json",
+        "--current", "/tmp/cur.json",
+        "--array-path", "entries",
+        "--key-field", "idx",
+      ]),
+    ).toThrow(/--incoming/);
+  });
+
+  it("throws when --array-path is missing and no --config", () => {
+    expect(() =>
+      parseMergeAppendableArgs([
+        "--base", "/tmp/base.json",
+        "--current", "/tmp/cur.json",
+        "--incoming", "/tmp/inc.json",
+        "--key-field", "idx",
+      ]),
+    ).toThrow(/--array-path/);
+  });
+
+  it("throws when --key-field is missing and no --config", () => {
+    expect(() =>
+      parseMergeAppendableArgs([
+        "--base", "/tmp/base.json",
+        "--current", "/tmp/cur.json",
+        "--incoming", "/tmp/inc.json",
+        "--array-path", "entries",
+      ]),
+    ).toThrow(/--key-field/);
+  });
+
+  it("throws on unknown flags", () => {
+    expect(() =>
+      parseMergeAppendableArgs([
+        "--base", "/tmp/base.json",
+        "--current", "/tmp/cur.json",
+        "--incoming", "/tmp/inc.json",
+        "--array-path", "entries",
+        "--key-field", "idx",
+        "--unknown-flag",
+      ]),
+    ).toThrow(/Unknown argument/);
+  });
+
+  it("throws on duplicate flags", () => {
+    expect(() =>
+      parseMergeAppendableArgs([
+        "--base", "/tmp/base.json",
+        "--base", "/tmp/base2.json",
+        "--current", "/tmp/cur.json",
+        "--incoming", "/tmp/inc.json",
+        "--array-path", "entries",
+        "--key-field", "idx",
+      ]),
+    ).toThrow(/--base given more than once/);
+  });
+
+  it("throws when a flag value looks like another flag", () => {
+    expect(() =>
+      parseMergeAppendableArgs([
+        "--base", "--current",
+        "--current", "/tmp/cur.json",
+        "--incoming", "/tmp/inc.json",
+        "--array-path", "entries",
+        "--key-field", "idx",
+      ]),
+    ).toThrow(/--base/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseMergeAppendableArgs — resolve mode
+// ---------------------------------------------------------------------------
+
+describe("parseMergeAppendableArgs — resolve mode", () => {
+  it("parses all required resolve flags", () => {
+    const args = parseMergeAppendableArgs([
+      "--resolve", "/repo/db/meta/_journal.json",
+      "--array-path", "entries",
+      "--key-field", "idx",
+    ]);
+    expect(args).toEqual({
+      mode: "resolve",
+      file: "/repo/db/meta/_journal.json",
+      arrayPath: "entries",
+      keyField: "idx",
+      baseBranch: "main",
+    });
+  });
+
+  it("accepts a custom --base-branch", () => {
+    const args = parseMergeAppendableArgs([
+      "--resolve", "/repo/file.json",
+      "--array-path", "entries",
+      "--key-field", "idx",
+      "--base-branch", "develop",
+    ]);
+    expect(args.mode === "resolve" && args.baseBranch).toBe("develop");
+  });
+
+  it("throws when --array-path is missing in resolve mode", () => {
+    expect(() =>
+      parseMergeAppendableArgs([
+        "--resolve", "/repo/file.json",
+        "--key-field", "idx",
+      ]),
+    ).toThrow(/--array-path/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runMergeDriver
+// ---------------------------------------------------------------------------
+
+const journalBase = JSON.stringify({
+  version: "7",
+  entries: [
+    { idx: 0, tag: "0000_init" },
+    { idx: 57, tag: "0057_prev" },
+  ],
+});
+const journalCurrent = JSON.stringify({
+  version: "7",
+  entries: [
+    { idx: 0, tag: "0000_init" },
+    { idx: 57, tag: "0057_prev" },
+    { idx: 61, tag: "0061_ours" },
+  ],
+});
+const journalIncoming = JSON.stringify({
+  version: "7",
+  entries: [
+    { idx: 0, tag: "0000_init" },
+    { idx: 57, tag: "0057_prev" },
+    { idx: 62, tag: "0062_theirs" },
+  ],
+});
+
+describe("runMergeDriver", () => {
+  it("reads base/current/incoming and writes merged result to current path", () => {
+    const files: Record<string, string> = {
+      "/tmp/base.json": journalBase,
+      "/tmp/cur.json": journalCurrent,
+      "/tmp/inc.json": journalIncoming,
+    };
+    const written: Record<string, string> = {};
+
+    runMergeDriver(
+      {
+        mode: "driver",
+        base: "/tmp/base.json",
+        current: "/tmp/cur.json",
+        incoming: "/tmp/inc.json",
+        arrayPath: "entries",
+        keyField: "idx",
+      },
+      {
+        readFile: (p) => files[p]!,
+        writeFile: (p, content) => { written[p] = content; },
+      },
+    );
+
+    expect(written["/tmp/cur.json"]).toBeDefined();
+    const result = JSON.parse(written["/tmp/cur.json"]!) as { entries: { idx: number }[] };
+    expect(result.entries.map((e) => e.idx)).toEqual([0, 57, 61, 62]);
+  });
+
+  it("writes valid JSON", () => {
+    const files: Record<string, string> = {
+      "/tmp/base.json": journalBase,
+      "/tmp/cur.json": journalCurrent,
+      "/tmp/inc.json": journalIncoming,
+    };
+    const written: Record<string, string> = {};
+
+    runMergeDriver(
+      {
+        mode: "driver",
+        base: "/tmp/base.json",
+        current: "/tmp/cur.json",
+        incoming: "/tmp/inc.json",
+        arrayPath: "entries",
+        keyField: "idx",
+      },
+      {
+        readFile: (p) => files[p]!,
+        writeFile: (p, content) => { written[p] = content; },
+      },
+    );
+
+    expect(() => JSON.parse(written["/tmp/cur.json"]!)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ESM safety
+// ---------------------------------------------------------------------------
+
+describe("ESM safety", () => {
+  it("source contains no inline require() calls", () => {
+    const src = readFileSync(
+      fileURLToPath(new URL("../src/cli-merge-appendable.ts", import.meta.url)),
+      "utf-8",
+    );
+    const stripped = src
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/\/\/.*$/gm, "");
+    expect(stripped).not.toMatch(/\brequire\s*\(/);
+  });
+});

--- a/__tests__/merge-appendable.test.ts
+++ b/__tests__/merge-appendable.test.ts
@@ -1,0 +1,348 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+import {
+  getNestedArray,
+  setNestedArray,
+  extractJsonObjects,
+  parseConflictSections,
+  mergeJsonArrays,
+  mergeJsonDocuments,
+  resolveConflict,
+} from "../src/merge-appendable.js";
+
+// ---------------------------------------------------------------------------
+// getNestedArray
+// ---------------------------------------------------------------------------
+
+describe("getNestedArray", () => {
+  it("returns a top-level array", () => {
+    const doc = { entries: [{ idx: 0 }, { idx: 1 }] };
+    expect(getNestedArray(doc, "entries")).toEqual([{ idx: 0 }, { idx: 1 }]);
+  });
+
+  it("navigates dot-separated paths", () => {
+    const doc = { meta: { entries: [{ idx: 0 }] } };
+    expect(getNestedArray(doc, "meta.entries")).toEqual([{ idx: 0 }]);
+  });
+
+  it("throws when path does not point to an array", () => {
+    const doc = { entries: "not an array" };
+    expect(() => getNestedArray(doc, "entries")).toThrow(/array/);
+  });
+
+  it("throws when an intermediate key is missing", () => {
+    const doc = { other: {} };
+    expect(() => getNestedArray(doc, "meta.entries")).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setNestedArray
+// ---------------------------------------------------------------------------
+
+describe("setNestedArray", () => {
+  it("replaces a top-level array, preserving other fields", () => {
+    const doc = { version: "7", entries: [{ idx: 0 }] };
+    const result = setNestedArray(doc, "entries", [{ idx: 0 }, { idx: 1 }]);
+    expect(result).toEqual({ version: "7", entries: [{ idx: 0 }, { idx: 1 }] });
+  });
+
+  it("replaces a nested array", () => {
+    const doc = { meta: { dialect: "pg", entries: [{ idx: 0 }] }, version: "7" };
+    const result = setNestedArray(doc, "meta.entries", [{ idx: 0 }, { idx: 1 }]);
+    expect(result).toEqual({
+      version: "7",
+      meta: { dialect: "pg", entries: [{ idx: 0 }, { idx: 1 }] },
+    });
+  });
+
+  it("does not mutate the original document", () => {
+    const doc = { entries: [{ idx: 0 }] };
+    setNestedArray(doc, "entries", [{ idx: 0 }, { idx: 1 }]);
+    expect(doc.entries).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractJsonObjects
+// ---------------------------------------------------------------------------
+
+describe("extractJsonObjects", () => {
+  it("extracts a single complete object", () => {
+    const text = `  { "idx": 61, "tag": "0061_foo" }  `;
+    expect(extractJsonObjects(text)).toEqual([{ idx: 61, tag: "0061_foo" }]);
+  });
+
+  it("extracts multiple objects from a comma-separated list", () => {
+    const text = `{ "idx": 61, "tag": "a" },\n  { "idx": 62, "tag": "b" }`;
+    const objs = extractJsonObjects(text);
+    expect(objs).toHaveLength(2);
+    expect(objs[0]).toEqual({ idx: 61, tag: "a" });
+    expect(objs[1]).toEqual({ idx: 62, tag: "b" });
+  });
+
+  it("skips partial/broken objects and returns only parseable ones", () => {
+    // Simulate a conflict that broke an object mid-way
+    const text = `    { "idx": 62, "tag": "b" }\n  ]\n}`;
+    const objs = extractJsonObjects(text);
+    expect(objs).toHaveLength(1);
+    expect(objs[0]).toEqual({ idx: 62, tag: "b" });
+  });
+
+  it("returns empty array when no objects are present", () => {
+    expect(extractJsonObjects("  ]\n}\n")).toEqual([]);
+  });
+
+  it("handles multi-line objects", () => {
+    const text = `{\n  "idx": 61,\n  "tag": "0061_foo",\n  "breakpoints": true\n}`;
+    const objs = extractJsonObjects(text);
+    expect(objs).toHaveLength(1);
+    expect(objs[0]).toEqual({ idx: 61, tag: "0061_foo", breakpoints: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseConflictSections
+// ---------------------------------------------------------------------------
+
+describe("parseConflictSections", () => {
+  it("returns null when there are no conflict markers", () => {
+    expect(parseConflictSections('{"entries": []}')).toBeNull();
+  });
+
+  it("returns ours and theirs sections from a conflict block", () => {
+    const content = [
+      "<<<<<<< HEAD",
+      '    {"idx": 61, "tag": "0061_a"}',
+      "=======",
+      '    {"idx": 62, "tag": "0062_b"}',
+      ">>>>>>> branch",
+    ].join("\n");
+    const sections = parseConflictSections(content);
+    expect(sections).not.toBeNull();
+    expect(sections!.ours).toContain('"idx": 61');
+    expect(sections!.theirs).toContain('"idx": 62');
+  });
+
+  it("ours does not contain the marker lines themselves", () => {
+    const content = "<<<<<<< HEAD\n  line\n=======\n  other\n>>>>>>> x";
+    const sections = parseConflictSections(content)!;
+    expect(sections.ours).not.toMatch(/^<{7}/m);
+    expect(sections.ours).not.toMatch(/^={7}/m);
+    expect(sections.theirs).not.toMatch(/^={7}/m);
+    expect(sections.theirs).not.toMatch(/^>{7}/m);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mergeJsonArrays
+// ---------------------------------------------------------------------------
+
+describe("mergeJsonArrays", () => {
+  const base = [{ idx: 0 }, { idx: 57 }];
+  const current = [{ idx: 0 }, { idx: 57 }, { idx: 61 }];
+  const incoming = [{ idx: 0 }, { idx: 57 }, { idx: 62 }];
+
+  it("merges by keyField with no collision", () => {
+    const result = mergeJsonArrays(base, current, incoming, "idx");
+    expect(result.map((e) => e.idx)).toEqual([0, 57, 61, 62]);
+  });
+
+  it("sorts entries by keyField numerically", () => {
+    const result = mergeJsonArrays(
+      [{ idx: 0 }],
+      [{ idx: 0 }, { idx: 10 }],
+      [{ idx: 0 }, { idx: 9 }],
+      "idx",
+    );
+    expect(result.map((e) => e.idx)).toEqual([0, 9, 10]);
+  });
+
+  it("sorts string keyField values lexicographically", () => {
+    const result = mergeJsonArrays(
+      [{ name: "a" }],
+      [{ name: "a" }, { name: "c" }],
+      [{ name: "a" }, { name: "b" }],
+      "name",
+    );
+    expect(result.map((e) => e.name)).toEqual(["a", "b", "c"]);
+  });
+
+  it("throws on a genuine keyField collision between ours and theirs", () => {
+    expect(() =>
+      mergeJsonArrays(
+        [{ idx: 0 }],
+        [{ idx: 0 }, { idx: 61, tag: "a" }],
+        [{ idx: 0 }, { idx: 61, tag: "b" }],
+        "idx",
+      ),
+    ).toThrow(/collision/i);
+  });
+
+  it("handles an empty base", () => {
+    const result = mergeJsonArrays(
+      [],
+      [{ idx: 1 }],
+      [{ idx: 2 }],
+      "idx",
+    );
+    expect(result.map((e) => e.idx)).toEqual([1, 2]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mergeJsonDocuments — git driver mode
+// ---------------------------------------------------------------------------
+
+const drizzleBase = JSON.stringify({
+  version: "7",
+  dialect: "postgresql",
+  entries: [
+    { idx: 0, version: "6", when: 1700000000000, tag: "0000_init", breakpoints: true },
+    { idx: 57, version: "6", when: 1701000000000, tag: "0057_feature", breakpoints: true },
+  ],
+});
+
+const drizzleCurrent = JSON.stringify({
+  version: "7",
+  dialect: "postgresql",
+  entries: [
+    { idx: 0, version: "6", when: 1700000000000, tag: "0000_init", breakpoints: true },
+    { idx: 57, version: "6", when: 1701000000000, tag: "0057_feature", breakpoints: true },
+    { idx: 61, version: "6", when: 1702000000000, tag: "0061_new", breakpoints: true },
+  ],
+});
+
+const drizzleIncoming = JSON.stringify({
+  version: "7",
+  dialect: "postgresql",
+  entries: [
+    { idx: 0, version: "6", when: 1700000000000, tag: "0000_init", breakpoints: true },
+    { idx: 57, version: "6", when: 1701000000000, tag: "0057_feature", breakpoints: true },
+    { idx: 62, version: "6", when: 1702000000001, tag: "0062_other", breakpoints: true },
+  ],
+});
+
+describe("mergeJsonDocuments", () => {
+  it("merges two diverged journal files sharing a common base", () => {
+    const result = mergeJsonDocuments(drizzleBase, drizzleCurrent, drizzleIncoming, {
+      arrayPath: "entries",
+      keyField: "idx",
+    });
+    const parsed = JSON.parse(result) as { version: string; entries: { idx: number }[] };
+    expect(parsed.version).toBe("7");
+    expect(parsed.entries.map((e) => e.idx)).toEqual([0, 57, 61, 62]);
+  });
+
+  it("preserves top-level document fields other than the array", () => {
+    const result = mergeJsonDocuments(drizzleBase, drizzleCurrent, drizzleIncoming, {
+      arrayPath: "entries",
+      keyField: "idx",
+    });
+    const parsed = JSON.parse(result) as { dialect: string };
+    expect(parsed.dialect).toBe("postgresql");
+  });
+
+  it("returns valid JSON", () => {
+    const result = mergeJsonDocuments(drizzleBase, drizzleCurrent, drizzleIncoming, {
+      arrayPath: "entries",
+      keyField: "idx",
+    });
+    expect(() => JSON.parse(result)).not.toThrow();
+  });
+
+  it("throws when ours and theirs each add the same key", () => {
+    const collision = JSON.stringify({
+      version: "7",
+      dialect: "postgresql",
+      entries: [
+        { idx: 0 },
+        { idx: 57 },
+        { idx: 61, tag: "0061_collision" },
+      ],
+    });
+    expect(() =>
+      mergeJsonDocuments(drizzleBase, collision, collision, {
+        arrayPath: "entries",
+        keyField: "idx",
+      }),
+    ).toThrow(/collision/i);
+  });
+
+  it("works with dot-path arrayPath", () => {
+    const toDoc = (entries: unknown[]) =>
+      JSON.stringify({ meta: { dialect: "pg", entries } });
+    const base = toDoc([{ idx: 0 }]);
+    const current = toDoc([{ idx: 0 }, { idx: 1 }]);
+    const incoming = toDoc([{ idx: 0 }, { idx: 2 }]);
+    const result = mergeJsonDocuments(base, current, incoming, {
+      arrayPath: "meta.entries",
+      keyField: "idx",
+    });
+    const parsed = JSON.parse(result) as { meta: { entries: { idx: number }[] } };
+    expect(parsed.meta.entries.map((e) => e.idx)).toEqual([0, 1, 2]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveConflict — manual/post-conflict mode
+// ---------------------------------------------------------------------------
+
+describe("resolveConflict", () => {
+  it("returns the content unchanged when no conflict markers are present", () => {
+    const clean = JSON.stringify({ version: "7", entries: [{ idx: 0 }] }, null, 2);
+    const result = resolveConflict(clean, clean, { arrayPath: "entries", keyField: "idx" });
+    expect(JSON.parse(result)).toEqual(JSON.parse(clean));
+  });
+
+  it("resolves a simple conflict with one entry per side", () => {
+    // Simulate a git conflict in _journal.json
+    const conflictContent = [
+      "{",
+      '  "version": "7",',
+      '  "entries": [',
+      '    {"idx": 0, "tag": "0000_init"},',
+      '    {"idx": 57, "tag": "0057_feat"},',
+      "<<<<<<< HEAD",
+      '    {"idx": 61, "tag": "0061_a"}',
+      "=======",
+      '    {"idx": 62, "tag": "0062_b"}',
+      ">>>>>>> other-branch",
+      "  ]",
+      "}",
+    ].join("\n");
+
+    const baseContent = JSON.stringify({
+      version: "7",
+      entries: [
+        { idx: 0, tag: "0000_init" },
+        { idx: 57, tag: "0057_feat" },
+      ],
+    });
+
+    const result = resolveConflict(conflictContent, baseContent, {
+      arrayPath: "entries",
+      keyField: "idx",
+    });
+    const parsed = JSON.parse(result) as { entries: { idx: number }[] };
+    expect(parsed.entries.map((e) => e.idx)).toEqual([0, 57, 61, 62]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ESM safety
+// ---------------------------------------------------------------------------
+
+describe("ESM safety", () => {
+  it("source contains no inline require() calls", () => {
+    const src = readFileSync(
+      fileURLToPath(new URL("../src/merge-appendable.ts", import.meta.url)),
+      "utf-8",
+    );
+    const stripped = src
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/\/\/.*$/gm, "");
+    expect(stripped).not.toMatch(/\brequire\s*\(/);
+  });
+});

--- a/__tests__/yaml-schema.test.ts
+++ b/__tests__/yaml-schema.test.ts
@@ -312,6 +312,70 @@ describe("YamlConfigSchema", () => {
     });
   });
 
+  describe("appendableFiles", () => {
+    it("accepts a valid appendableFiles entry", () => {
+      const result = YamlConfigSchema.safeParse(
+        makeValid({
+          appendableFiles: [
+            {
+              path: "shared/db/meta/_journal.json",
+              format: "json-array",
+              arrayPath: "entries",
+              keyField: "idx",
+            },
+          ],
+        }),
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts multiple appendableFiles entries", () => {
+      const result = YamlConfigSchema.safeParse(
+        makeValid({
+          appendableFiles: [
+            { path: "db/_journal.json", format: "json-array", arrayPath: "entries", keyField: "idx" },
+            { path: "logs/changelog.json", format: "json-array", arrayPath: "log.items", keyField: "id" },
+          ],
+        }),
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects an unknown format", () => {
+      const result = YamlConfigSchema.safeParse(
+        makeValid({
+          appendableFiles: [
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            { path: "db/_journal.json", format: "csv" as any, arrayPath: "entries", keyField: "idx" },
+          ],
+        }),
+      );
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects an entry with an empty path", () => {
+      const result = YamlConfigSchema.safeParse(
+        makeValid({
+          appendableFiles: [
+            { path: "", format: "json-array", arrayPath: "entries", keyField: "idx" },
+          ],
+        }),
+      );
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects an entry with an empty keyField", () => {
+      const result = YamlConfigSchema.safeParse(
+        makeValid({
+          appendableFiles: [
+            { path: "db/_journal.json", format: "json-array", arrayPath: "entries", keyField: "" },
+          ],
+        }),
+      );
+      expect(result.success).toBe(false);
+    });
+  });
+
   describe("defaults", () => {
     it("defaults dependsOn to empty array when omitted", () => {
       const input = makeValid({

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     }
   },
   "bin": {
-    "claude-orchestrator-claim": "dist/src/cli-claim.js"
+    "claude-orchestrator-claim": "dist/src/cli-claim.js",
+    "claude-orchestrator-merge-appendable": "dist/src/cli-merge-appendable.js"
   },
   "files": [
     "dist/src"

--- a/src/cli-merge-appendable.ts
+++ b/src/cli-merge-appendable.ts
@@ -1,0 +1,304 @@
+#!/usr/bin/env node
+/**
+ * CLI command for merging append-style JSON array files such as Drizzle's
+ * `_journal.json`.
+ *
+ * Two modes:
+ *
+ * **Git merge driver mode** — wired via `.gitattributes`:
+ *   ```
+ *   npx claude-orchestrator-merge-appendable \
+ *     --base %O --current %A --incoming %B \
+ *     --array-path entries --key-field idx
+ *   ```
+ *   Git invokes this automatically during `git merge` / `git rebase`.
+ *   The result is written to the file passed as `--current` (git's `%A`).
+ *
+ * **Manual/post-conflict mode** — invoked by the user after a failed merge:
+ *   ```
+ *   npx claude-orchestrator-merge-appendable \
+ *     --resolve path/to/_journal.json \
+ *     --array-path entries --key-field idx \
+ *     [--base-branch main]
+ *   ```
+ *   The base is read from `git show origin/<baseBranch>:<relPath>`.
+ *
+ * In both modes `--array-path` and `--key-field` may be replaced with
+ * `--config <yaml>` + `--path <file-path>` to look up the configuration from
+ * an `appendableFiles` entry in the orchestrator YAML config.
+ *
+ * ## Setting up the git merge driver
+ *
+ * 1. Add to `.gitattributes`:
+ *    ```
+ *    path/to/_journal.json merge=orchestrator-appendable
+ *    ```
+ *
+ * 2. Register the driver (once, per repo clone):
+ *    ```
+ *    git config merge.orchestrator-appendable.driver \
+ *      "npx claude-orchestrator-merge-appendable --base %O --current %A --incoming %B --array-path entries --key-field idx"
+ *    ```
+ *    Or with a YAML config file:
+ *    ```
+ *    git config merge.orchestrator-appendable.driver \
+ *      "npx claude-orchestrator-merge-appendable --base %O --current %A --incoming %B --config .orchestrator/config.yaml --path path/to/_journal.json"
+ *    ```
+ *
+ * Pure helpers (`parseMergeAppendableArgs`, `runMergeDriver`, `runResolve`)
+ * are exported for unit testing.
+ */
+
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse as parseYaml } from "yaml";
+import { YamlConfigSchema } from "./yaml-schema.js";
+import { resolveYamlPaths } from "./yaml-loader.js";
+import type { YamlConfig } from "./yaml-types.js";
+import type { AppendableFileSpec } from "./yaml-types.js";
+import { mergeJsonDocuments, resolveConflict } from "./merge-appendable.js";
+
+// ---------------------------------------------------------------------------
+// Argument types
+// ---------------------------------------------------------------------------
+
+/** Arguments for git merge driver mode. */
+export interface MergeDriverArgs {
+  mode: "driver";
+  base: string;
+  current: string;
+  incoming: string;
+  arrayPath: string;
+  keyField: string;
+}
+
+/** Arguments for manual/post-conflict resolution mode. */
+export interface ResolveArgs {
+  mode: "resolve";
+  file: string;
+  arrayPath: string;
+  keyField: string;
+  /** Branch to read the base from. Default: `"main"`. */
+  baseBranch: string;
+}
+
+export type MergeAppendableArgs = MergeDriverArgs | ResolveArgs;
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+function takeValue(argv: string[], i: number, flag: string): string {
+  const v = argv[i + 1];
+  if (v === undefined || v.startsWith("--")) {
+    throw new Error(`${flag} requires an argument`);
+  }
+  return v;
+}
+
+function loadAppendableConfig(
+  yamlPath: string,
+  filePath: string,
+): Pick<AppendableFileSpec, "arrayPath" | "keyField"> {
+  const raw = fs.readFileSync(yamlPath, "utf-8");
+  const parsed = parseYaml(raw) as unknown;
+  const yaml = YamlConfigSchema.parse(parsed) as YamlConfig;
+  resolveYamlPaths(yaml, path.dirname(path.resolve(yamlPath)));
+
+  if (!yaml.appendableFiles || yaml.appendableFiles.length === 0) {
+    throw new Error(`No appendableFiles configured in ${yamlPath}`);
+  }
+  const entry = yaml.appendableFiles.find((f) => f.path === filePath);
+  if (!entry) {
+    const known = yaml.appendableFiles.map((f) => f.path).join(", ");
+    throw new Error(
+      `No appendableFiles entry for path "${filePath}" in ${yamlPath}. Known: ${known}`,
+    );
+  }
+  return { arrayPath: entry.arrayPath, keyField: entry.keyField };
+}
+
+export function parseMergeAppendableArgs(argv: string[]): MergeAppendableArgs {
+  let base: string | undefined;
+  let current: string | undefined;
+  let incoming: string | undefined;
+  let resolve: string | undefined;
+  let arrayPath: string | undefined;
+  let keyField: string | undefined;
+  let config: string | undefined;
+  let configPath: string | undefined;
+  let baseBranch = "main";
+
+  let i = 0;
+  while (i < argv.length) {
+    const arg = argv[i]!;
+    switch (arg) {
+      case "--base": {
+        if (base !== undefined) throw new Error("--base given more than once");
+        base = takeValue(argv, i, "--base");
+        i += 2;
+        break;
+      }
+      case "--current": {
+        if (current !== undefined) throw new Error("--current given more than once");
+        current = takeValue(argv, i, "--current");
+        i += 2;
+        break;
+      }
+      case "--incoming": {
+        if (incoming !== undefined) throw new Error("--incoming given more than once");
+        incoming = takeValue(argv, i, "--incoming");
+        i += 2;
+        break;
+      }
+      case "--resolve": {
+        if (resolve !== undefined) throw new Error("--resolve given more than once");
+        resolve = takeValue(argv, i, "--resolve");
+        i += 2;
+        break;
+      }
+      case "--array-path": {
+        if (arrayPath !== undefined) throw new Error("--array-path given more than once");
+        arrayPath = takeValue(argv, i, "--array-path");
+        i += 2;
+        break;
+      }
+      case "--key-field": {
+        if (keyField !== undefined) throw new Error("--key-field given more than once");
+        keyField = takeValue(argv, i, "--key-field");
+        i += 2;
+        break;
+      }
+      case "--config": {
+        if (config !== undefined) throw new Error("--config given more than once");
+        config = takeValue(argv, i, "--config");
+        i += 2;
+        break;
+      }
+      case "--path": {
+        if (configPath !== undefined) throw new Error("--path given more than once");
+        configPath = takeValue(argv, i, "--path");
+        i += 2;
+        break;
+      }
+      case "--base-branch": {
+        baseBranch = takeValue(argv, i, "--base-branch");
+        i += 2;
+        break;
+      }
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  // Resolve --array-path/--key-field from YAML config when --config+--path given
+  if (config !== undefined || configPath !== undefined) {
+    if (!config) throw new Error("--config is required when --path is given");
+    if (!configPath) throw new Error("--path is required when --config is given");
+    const fromConfig = loadAppendableConfig(config, configPath);
+    if (arrayPath === undefined) arrayPath = fromConfig.arrayPath;
+    if (keyField === undefined) keyField = fromConfig.keyField;
+  }
+
+  if (resolve !== undefined) {
+    // Manual mode
+    if (!arrayPath) throw new Error("--array-path is required (or provide --config + --path)");
+    if (!keyField) throw new Error("--key-field is required (or provide --config + --path)");
+    return { mode: "resolve", file: resolve, arrayPath, keyField, baseBranch };
+  }
+
+  // Git driver mode
+  if (!base) throw new Error("--base is required");
+  if (!current) throw new Error("--current is required");
+  if (!incoming) throw new Error("--incoming is required");
+  if (!arrayPath) throw new Error("--array-path is required (or provide --config + --path)");
+  if (!keyField) throw new Error("--key-field is required (or provide --config + --path)");
+
+  return { mode: "driver", base, current, incoming, arrayPath, keyField };
+}
+
+// ---------------------------------------------------------------------------
+// Execution helpers
+// ---------------------------------------------------------------------------
+
+export interface RunMergeDriverDeps {
+  readFile: (p: string) => string;
+  writeFile: (p: string, content: string) => void;
+}
+
+export function runMergeDriver(
+  args: MergeDriverArgs,
+  deps: RunMergeDriverDeps,
+): void {
+  const base = deps.readFile(args.base);
+  const current = deps.readFile(args.current);
+  const incoming = deps.readFile(args.incoming);
+  const merged = mergeJsonDocuments(base, current, incoming, {
+    arrayPath: args.arrayPath,
+    keyField: args.keyField,
+  });
+  deps.writeFile(args.current, merged);
+}
+
+export interface RunResolveDeps {
+  readFile: (p: string) => string;
+  writeFile: (p: string, content: string) => void;
+  runCommand: (cmd: string) => string;
+  cwd: string;
+}
+
+export function runResolve(args: ResolveArgs, deps: RunResolveDeps): void {
+  const conflictContent = deps.readFile(args.file);
+
+  // Determine the file's path relative to the repo root so we can git-show it.
+  const repoRoot = deps
+    .runCommand(`git -C ${JSON.stringify(deps.cwd)} rev-parse --show-toplevel`)
+    .trim();
+  const absFile = path.resolve(args.file);
+  const relFile = path.relative(repoRoot, absFile);
+
+  const baseContent = deps.runCommand(
+    `git -C ${JSON.stringify(repoRoot)} show origin/${args.baseBranch}:${JSON.stringify(relFile)}`,
+  );
+
+  const resolved = resolveConflict(conflictContent, baseContent, {
+    arrayPath: args.arrayPath,
+    keyField: args.keyField,
+  });
+  deps.writeFile(args.file, resolved);
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point
+// ---------------------------------------------------------------------------
+
+function main(): void {
+  const args = parseMergeAppendableArgs(process.argv.slice(2));
+
+  if (args.mode === "driver") {
+    runMergeDriver(args, {
+      readFile: (p) => fs.readFileSync(p, "utf-8"),
+      writeFile: (p, content) => fs.writeFileSync(p, content, "utf-8"),
+    });
+  } else {
+    runResolve(args, {
+      readFile: (p) => fs.readFileSync(p, "utf-8"),
+      writeFile: (p, content) => fs.writeFileSync(p, content, "utf-8"),
+      runCommand: (cmd) => execSync(cmd, { encoding: "utf-8" }),
+      cwd: process.cwd(),
+    });
+  }
+}
+
+const entryPath = process.argv[1] ? path.resolve(process.argv[1]) : "";
+const thisFile = fileURLToPath(import.meta.url);
+if (entryPath === thisFile) {
+  try {
+    main();
+  } catch (err) {
+    process.stderr.write(`merge-appendable failed: ${(err as Error).message}\n`);
+    process.exit(1);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,28 @@ export type {
   YamlIssue,
   SequentialPathConfig,
   SequentialDomainConfig,
+  AppendableFileSpec,
 } from "./yaml-types.js";
+
+// Journal-aware merge driver (issue #37)
+export {
+  getNestedArray,
+  setNestedArray,
+  extractJsonObjects,
+  parseConflictSections,
+  mergeJsonArrays,
+  mergeJsonDocuments,
+  resolveConflict,
+} from "./merge-appendable.js";
+export type { AppendableFileConfig } from "./merge-appendable.js";
+export { parseMergeAppendableArgs, runMergeDriver, runResolve } from "./cli-merge-appendable.js";
+export type {
+  MergeDriverArgs,
+  ResolveArgs,
+  MergeAppendableArgs,
+  RunMergeDriverDeps,
+  RunResolveDeps,
+} from "./cli-merge-appendable.js";
 
 // Sequential-number coordination (issue #25)
 export {

--- a/src/merge-appendable.ts
+++ b/src/merge-appendable.ts
@@ -1,0 +1,292 @@
+/**
+ * Journal-aware merge driver for append-only JSON array files.
+ *
+ * Provides pure merge functions used by the `claude-orchestrator-merge-appendable`
+ * CLI command. The primary use case is Drizzle's `_journal.json`, but the logic
+ * is general: any file that is a JSON document containing an array that grows
+ * by appending unique keyed entries (e.g. migration indices, changelog entries).
+ *
+ * Two resolution modes are supported:
+ *   1. Git merge driver mode — called by git with three clean file paths
+ *      (`%O` base, `%A` ours, `%B` theirs). No conflict markers in any file.
+ *      Use `mergeJsonDocuments`.
+ *   2. Manual/post-conflict mode — user invokes on a file that already has
+ *      git conflict markers. Use `resolveConflict` with a separate base string.
+ */
+
+/** Configuration for one appendable file. Declared in the YAML config. */
+export interface AppendableFileConfig {
+  /** Path to the file, relative to the project root. */
+  path: string;
+  /** File format. Currently only "json-array" is supported. */
+  format: "json-array";
+  /** Dot-separated path to the array within the document (e.g. `"entries"` or `"meta.entries"`). */
+  arrayPath: string;
+  /** Field whose value uniquely identifies each entry (e.g. `"idx"`). */
+  keyField: string;
+}
+
+// ---------------------------------------------------------------------------
+// Document navigation helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the array at `arrayPath` inside `doc`. `arrayPath` is a
+ * dot-separated key path (e.g. `"entries"` or `"meta.entries"`).
+ * Throws if the path does not resolve to an array.
+ */
+export function getNestedArray(doc: unknown, arrayPath: string): Record<string, unknown>[] {
+  const parts = arrayPath.split(".");
+  let node: unknown = doc;
+  for (const part of parts) {
+    if (typeof node !== "object" || node === null) {
+      throw new Error(
+        `Cannot navigate path "${arrayPath}": expected object before "${part}" but got ${typeof node}`,
+      );
+    }
+    node = (node as Record<string, unknown>)[part];
+  }
+  if (!Array.isArray(node)) {
+    throw new Error(
+      `Path "${arrayPath}" does not point to an array (got ${Array.isArray(node) ? "array" : typeof node})`,
+    );
+  }
+  return node as Record<string, unknown>[];
+}
+
+/**
+ * Returns a shallow copy of `doc` with the array at `arrayPath` replaced by
+ * `value`. Does not mutate `doc`.
+ */
+export function setNestedArray(doc: unknown, arrayPath: string, value: unknown[]): unknown {
+  const dotIdx = arrayPath.indexOf(".");
+  if (dotIdx === -1) {
+    return { ...(doc as Record<string, unknown>), [arrayPath]: value };
+  }
+  const head = arrayPath.slice(0, dotIdx);
+  const tail = arrayPath.slice(dotIdx + 1);
+  const parent = doc as Record<string, unknown>;
+  return {
+    ...parent,
+    [head]: setNestedArray(parent[head], tail, value),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Partial-text JSON extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Extracts all complete JSON objects from `text` using a brace-depth counter.
+ * This is intentionally lenient: conflict markers, trailing commas, and other
+ * surrounding noise are silently skipped. Only balanced `{...}` blocks that
+ * parse as valid JSON objects are returned.
+ *
+ * Used when the "theirs" or "ours" conflict section may contain partial object
+ * text due to git splitting entries mid-line.
+ */
+export function extractJsonObjects(text: string): Record<string, unknown>[] {
+  const results: Record<string, unknown>[] = [];
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escaped = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i]!;
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (ch === "\\" && inString) {
+      escaped = true;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+
+    if (ch === "{") {
+      if (depth === 0) start = i;
+      depth++;
+    } else if (ch === "}") {
+      depth--;
+      if (depth === 0 && start !== -1) {
+        const block = text.slice(start, i + 1);
+        try {
+          const obj = JSON.parse(block) as unknown;
+          if (typeof obj === "object" && obj !== null && !Array.isArray(obj)) {
+            results.push(obj as Record<string, unknown>);
+          }
+        } catch {
+          // ignore non-parseable blocks
+        }
+        start = -1;
+      }
+    }
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Conflict marker parsing
+// ---------------------------------------------------------------------------
+
+const CONFLICT_START = "<<<<<<<";
+const CONFLICT_MID = "=======";
+const CONFLICT_END = ">>>>>>>";
+
+/**
+ * Parses the first git conflict block in `content` and returns the ours
+ * section (between `<<<<<<<` and `=======`) and theirs section (between
+ * `=======` and `>>>>>>>`). Returns `null` when no conflict markers are found.
+ *
+ * Only the first conflict block is considered; for journal files a single
+ * conflict block is the expected shape.
+ */
+export function parseConflictSections(
+  content: string,
+): { ours: string; theirs: string } | null {
+  const startIdx = content.indexOf(CONFLICT_START);
+  const midIdx = content.indexOf(CONFLICT_MID);
+  const endIdx = content.indexOf(CONFLICT_END);
+
+  if (startIdx === -1 || midIdx === -1 || endIdx === -1) return null;
+  if (!(startIdx < midIdx && midIdx < endIdx)) return null;
+
+  const oursStart = content.indexOf("\n", startIdx) + 1;
+  const oursEnd = midIdx;
+  const theirsStart = content.indexOf("\n", midIdx) + 1;
+  const theirsEnd = endIdx;
+
+  return {
+    ours: content.slice(oursStart, oursEnd).trimEnd(),
+    theirs: content.slice(theirsStart, theirsEnd).trimEnd(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Array merge logic
+// ---------------------------------------------------------------------------
+
+function compareKeys(a: unknown, b: unknown): number {
+  if (typeof a === "number" && typeof b === "number") return a - b;
+  return String(a).localeCompare(String(b), undefined, { numeric: true });
+}
+
+/**
+ * Merges three versions of an append-only array by `keyField`.
+ *
+ * Algorithm:
+ *   - Determine what `current` added vs `base` (current-added).
+ *   - Determine what `incoming` added vs `base` (incoming-added).
+ *   - Throw if any key appears in both current-added and incoming-added
+ *     (that is a real collision the claim system should have prevented).
+ *   - Return base ∪ current-added ∪ incoming-added, sorted by keyField.
+ */
+export function mergeJsonArrays(
+  base: Record<string, unknown>[],
+  current: Record<string, unknown>[],
+  incoming: Record<string, unknown>[],
+  keyField: string,
+): Record<string, unknown>[] {
+  const baseKeys = new Set(base.map((e) => e[keyField]));
+
+  const currentAdded = current.filter((e) => !baseKeys.has(e[keyField]));
+  const incomingAdded = incoming.filter((e) => !baseKeys.has(e[keyField]));
+
+  const currentAddedKeys = new Set(currentAdded.map((e) => e[keyField]));
+  const colliding = incomingAdded.find((e) => currentAddedKeys.has(e[keyField]));
+  if (colliding) {
+    throw new Error(
+      `Collision on keyField "${keyField}" value ${JSON.stringify(colliding[keyField])}: ` +
+        `both branches added an entry with this key`,
+    );
+  }
+
+  const merged = [...base, ...currentAdded, ...incomingAdded];
+  merged.sort((a, b) => compareKeys(a[keyField], b[keyField]));
+  return merged;
+}
+
+// ---------------------------------------------------------------------------
+// Git merge driver entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Merges three complete JSON document strings (no conflict markers).
+ * Intended for use as a git merge driver where git provides clean ancestor,
+ * ours, and theirs files.
+ *
+ * The merged document is derived from `current` with its array at `arrayPath`
+ * replaced by the merged result.
+ */
+export function mergeJsonDocuments(
+  base: string,
+  current: string,
+  incoming: string,
+  config: Pick<AppendableFileConfig, "arrayPath" | "keyField">,
+): string {
+  const baseDoc = JSON.parse(base) as unknown;
+  const currentDoc = JSON.parse(current) as unknown;
+  const incomingDoc = JSON.parse(incoming) as unknown;
+
+  const baseArr = getNestedArray(baseDoc, config.arrayPath);
+  const currentArr = getNestedArray(currentDoc, config.arrayPath);
+  const incomingArr = getNestedArray(incomingDoc, config.arrayPath);
+
+  const merged = mergeJsonArrays(baseArr, currentArr, incomingArr, config.keyField);
+  const mergedDoc = setNestedArray(currentDoc, config.arrayPath, merged);
+  return JSON.stringify(mergedDoc, null, 2);
+}
+
+// ---------------------------------------------------------------------------
+// Manual / post-conflict resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolves a conflict-marked file using `baseContent` as the authoritative
+ * ancestor. If no conflict markers are found, returns `conflictContent`
+ * unchanged.
+ *
+ * Extracts JSON objects from the ours and theirs conflict sections using
+ * `extractJsonObjects` (robust against partially-split objects), then merges
+ * them against the base.
+ */
+export function resolveConflict(
+  conflictContent: string,
+  baseContent: string,
+  config: Pick<AppendableFileConfig, "arrayPath" | "keyField">,
+): string {
+  const sections = parseConflictSections(conflictContent);
+  if (!sections) return conflictContent;
+
+  const baseDoc = JSON.parse(baseContent) as unknown;
+  const baseArr = getNestedArray(baseDoc, config.arrayPath);
+
+  const oursEntries = extractJsonObjects(sections.ours);
+  const theirsEntries = extractJsonObjects(sections.theirs);
+
+  const baseKeys = new Set(baseArr.map((e) => e[config.keyField]));
+  const oursAdded = oursEntries.filter((e) => !baseKeys.has(e[config.keyField]));
+  const theirsAdded = theirsEntries.filter((e) => !baseKeys.has(e[config.keyField]));
+
+  const oursAddedKeys = new Set(oursAdded.map((e) => e[config.keyField]));
+  const colliding = theirsAdded.find((e) => oursAddedKeys.has(e[config.keyField]));
+  if (colliding) {
+    throw new Error(
+      `Collision on keyField "${config.keyField}" value ${JSON.stringify(colliding[config.keyField])}: ` +
+        `both branches added an entry with this key`,
+    );
+  }
+
+  const merged = [...baseArr, ...oursAdded, ...theirsAdded];
+  merged.sort((a, b) => compareKeys(a[config.keyField], b[config.keyField]));
+
+  const mergedDoc = setNestedArray(baseDoc, config.arrayPath, merged);
+  return JSON.stringify(mergedDoc, null, 2);
+}

--- a/src/yaml-schema.ts
+++ b/src/yaml-schema.ts
@@ -28,6 +28,13 @@ const YamlPostSessionCheckSchema = z.object({
   cwd: z.string().optional(),
 });
 
+const AppendableFileSpecSchema = z.object({
+  path: z.string().min(1),
+  format: z.literal("json-array"),
+  arrayPath: z.string().min(1),
+  keyField: z.string().min(1),
+});
+
 const SequentialPathConfigSchema = z.object({
   dir: z.string().min(1),
   pattern: z
@@ -80,6 +87,7 @@ export const YamlConfigSchema = z.object({
   retryOnCheckFailure: z.object({ maxRetries: z.number().int().positive(), enabled: z.boolean().optional() }).optional(),
   baseBranch: z.string().min(1).optional(),
   sequentialPaths: z.array(SequentialPathConfigSchema).optional(),
+  appendableFiles: z.array(AppendableFileSpecSchema).optional(),
   sequentialDomains: z
     .record(
       z

--- a/src/yaml-types.ts
+++ b/src/yaml-types.ts
@@ -48,6 +48,21 @@ export interface SequentialDomainConfig {
   width: number;
 }
 
+/**
+ * One append-style JSON array file wired to the journal-aware merge driver.
+ * Used in the `appendableFiles` YAML config field.
+ */
+export interface AppendableFileSpec {
+  /** Path to the file, relative to the project root. */
+  path: string;
+  /** File format. Currently only `"json-array"` is supported. */
+  format: "json-array";
+  /** Dot-separated path to the array within the document (e.g. `"entries"` or `"meta.entries"`). */
+  arrayPath: string;
+  /** Field whose value uniquely identifies each entry (e.g. `"idx"`). */
+  keyField: string;
+}
+
 /** Issue definition in a YAML config. */
 export interface YamlIssue {
   number: number;
@@ -102,6 +117,13 @@ export interface YamlConfig {
    * can request guaranteed-unique numbers instead of computing them locally.
    */
   sequentialDomains?: Record<string, SequentialDomainConfig>;
+  /**
+   * Append-style JSON array files for which a journal-aware git merge driver
+   * should be used. Each entry configures one file path with its array
+   * location and deduplication key. See `claude-orchestrator-merge-appendable`
+   * for setup instructions.
+   */
+  appendableFiles?: AppendableFileSpec[];
   issues: YamlIssue[];
 }
 


### PR DESCRIPTION
## Summary

- Adds `src/merge-appendable.ts` with pure merge logic for append-only JSON array files. Three-way merge (base/ours/theirs) deduplicates by a `keyField` and sorts — eliminating the manual conflict resolution step after every post-first PR in a parallel migration wave.
- Adds `claude-orchestrator-merge-appendable` bin command (`src/cli-merge-appendable.ts`) with two modes: **git merge driver** (`--base %O --current %A --incoming %B`) for automatic resolution during rebase/merge, and **manual resolve** (`--resolve <file>`) for post-conflict cleanup.
- Adds `appendableFiles` YAML config field (`path`, `format`, `arrayPath`, `keyField`) with Zod validation and `AppendableFileSpec` type.

## Setup (git merge driver)

1. Add to `.gitattributes`:
   ```
   path/to/_journal.json merge=orchestrator-appendable
   ```
2. Register the driver once per clone:
   ```
   git config merge.orchestrator-appendable.driver \
     "npx claude-orchestrator-merge-appendable --base %O --current %A --incoming %B --array-path entries --key-field idx"
   ```

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm test` passes (570 tests, 34 test files)
- [ ] New tests in `__tests__/merge-appendable.test.ts` cover core logic: `getNestedArray`, `setNestedArray`, `extractJsonObjects`, `parseConflictSections`, `mergeJsonArrays`, `mergeJsonDocuments`, `resolveConflict`
- [ ] New tests in `__tests__/cli-merge-appendable.test.ts` cover arg parsing (driver mode, resolve mode, error cases) and `runMergeDriver`
- [ ] New tests in `__tests__/yaml-schema.test.ts` cover `appendableFiles` schema validation

Closes #37