### PR TITLE
feat: detect same-file ownership conflicts in wave planner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ src/
 - **Dependency injection**: `Deps` interface for all external interactions
 - **In-memory testing**: All behavioral tests use `InMemoryStatusStore`,
   `InMemoryMetadataStore`, `createSilentLogger`, and mock `ProcessRunner`
-- **Wave scheduling**: `computeWaves()` topological sort from `dependsOn`
+- **Wave scheduling**: `computeWaves()` topological sort from `dependsOn`, with same-file ownership detection via `ownsFiles` (issues in the same candidate wave that claim overlapping non-shared files are slid to later waves by ascending issue number)
 - **Config validation**: Zod schema in `validateConfig()` with cycle detection
 - **YAML configs**: Alternative to pure-TS configs — `loadYamlConfig()` reads
   a YAML file, validates it, derives convention-based hooks, and merges
@@ -123,6 +123,12 @@ appendableFiles:
     arrayPath: "entries"
     keyField: "idx"
 
+# Files safe to overlap across parallel issues (ownsFiles allowlist).
+# appendableFiles paths are automatically exempt; list others here.
+sharedFiles:
+  - "package-lock.json"
+  - "tests/mocks/database.mock.ts"
+
 # Template variables: {{ISSUE_NUMBER}}, {{SLUG}}, {{DESCRIPTION}},
 # {{projectRoot}}, {{configDir}}, {{worktreeDir}}, {{UPSTREAM_CONTEXT}},
 # {{CLAIM_NUMBER}} (only when sequentialDomains is configured)
@@ -133,6 +139,7 @@ issues:
     dependsOn: []
     description: "Feature description"
     # serial: true  # optional; runs this issue alone in its own wave (e.g. for migrations)
+    # ownsFiles:    # optional; files this issue expects to write (triggers wave serialization on overlap)
 ```
 
 ### CLI Modes

--- a/__tests__/dag.test.ts
+++ b/__tests__/dag.test.ts
@@ -228,4 +228,119 @@ describe("computeWaves", () => {
       expect(byNumber.get(2)!.serial).toBeUndefined();
     });
   });
+
+  describe("ownsFiles conflict detection", () => {
+    it("two issues with no ownsFiles in the same wave are unaffected", () => {
+      const specs = [spec({ number: 1, slug: "a" }), spec({ number: 2, slug: "b" })];
+      const issues = computeWaves(specs);
+      const byNumber = new Map(issues.map((i) => [i.number, i]));
+      expect(byNumber.get(1)!.wave).toBe(1);
+      expect(byNumber.get(2)!.wave).toBe(1);
+    });
+
+    it("two issues with non-overlapping ownsFiles in the same wave are unaffected", () => {
+      const specs = [
+        spec({ number: 1, slug: "a", ownsFiles: ["src/a.ts"] }),
+        spec({ number: 2, slug: "b", ownsFiles: ["src/b.ts"] }),
+      ];
+      const issues = computeWaves(specs);
+      const byNumber = new Map(issues.map((i) => [i.number, i]));
+      expect(byNumber.get(1)!.wave).toBe(1);
+      expect(byNumber.get(2)!.wave).toBe(1);
+    });
+
+    it("slides the higher-numbered issue to the next wave when ownsFiles overlap", () => {
+      const specs = [
+        spec({ number: 1, slug: "a", ownsFiles: ["src/shared.ts"] }),
+        spec({ number: 2, slug: "b", ownsFiles: ["src/shared.ts"] }),
+      ];
+      const issues = computeWaves(specs);
+      const byNumber = new Map(issues.map((i) => [i.number, i]));
+      expect(byNumber.get(1)!.wave).toBe(1);
+      expect(byNumber.get(2)!.wave).toBe(2);
+    });
+
+    it("the lower-numbered issue always keeps its original wave", () => {
+      const specs = [
+        spec({ number: 5, slug: "e", ownsFiles: ["src/shared.ts"] }),
+        spec({ number: 1, slug: "a", ownsFiles: ["src/shared.ts"] }),
+      ];
+      const issues = computeWaves(specs);
+      const byNumber = new Map(issues.map((i) => [i.number, i]));
+      expect(byNumber.get(1)!.wave).toBe(1);
+      expect(byNumber.get(5)!.wave).toBe(2);
+    });
+
+    it("cascades three issues claiming the same file into separate waves", () => {
+      const specs = [
+        spec({ number: 1, slug: "a", ownsFiles: ["src/shared.ts"] }),
+        spec({ number: 2, slug: "b", ownsFiles: ["src/shared.ts"] }),
+        spec({ number: 3, slug: "c", ownsFiles: ["src/shared.ts"] }),
+      ];
+      const issues = computeWaves(specs);
+      const byNumber = new Map(issues.map((i) => [i.number, i]));
+      expect(byNumber.get(1)!.wave).toBe(1);
+      expect(byNumber.get(2)!.wave).toBe(2);
+      expect(byNumber.get(3)!.wave).toBe(3);
+    });
+
+    it("ignores files listed in ignoredOwnsFiles when checking for conflicts", () => {
+      const specs = [
+        spec({ number: 1, slug: "a", ownsFiles: ["package-lock.json"] }),
+        spec({ number: 2, slug: "b", ownsFiles: ["package-lock.json"] }),
+      ];
+      const issues = computeWaves(specs, { ignoredOwnsFiles: ["package-lock.json"] });
+      const byNumber = new Map(issues.map((i) => [i.number, i]));
+      expect(byNumber.get(1)!.wave).toBe(1);
+      expect(byNumber.get(2)!.wave).toBe(1);
+    });
+
+    it("only ignores the listed files, still detects conflicts on other files", () => {
+      const specs = [
+        spec({ number: 1, slug: "a", ownsFiles: ["package-lock.json", "src/shared.ts"] }),
+        spec({ number: 2, slug: "b", ownsFiles: ["package-lock.json", "src/shared.ts"] }),
+      ];
+      const issues = computeWaves(specs, { ignoredOwnsFiles: ["package-lock.json"] });
+      const byNumber = new Map(issues.map((i) => [i.number, i]));
+      expect(byNumber.get(1)!.wave).toBe(1);
+      expect(byNumber.get(2)!.wave).toBe(2);
+    });
+
+    it("issues in different original waves can claim the same file without conflict", () => {
+      const specs = [
+        spec({ number: 1, slug: "a", ownsFiles: ["src/shared.ts"] }),
+        spec({ number: 2, slug: "b", dependsOn: [1], ownsFiles: ["src/shared.ts"] }),
+      ];
+      const issues = computeWaves(specs);
+      const byNumber = new Map(issues.map((i) => [i.number, i]));
+      // #2 is already in wave 2 due to dependsOn, no further sliding needed
+      expect(byNumber.get(1)!.wave).toBe(1);
+      expect(byNumber.get(2)!.wave).toBe(2);
+    });
+
+    it("preserves ownsFiles on returned issues", () => {
+      const specs = [spec({ number: 1, slug: "a", ownsFiles: ["src/x.ts"] })];
+      const issues = computeWaves(specs);
+      expect(issues[0].ownsFiles).toEqual(["src/x.ts"]);
+    });
+
+    it("interacts correctly with serial: file conflict detection runs before serial splitting", () => {
+      // Two non-serial issues own the same file; one serial issue in the same wave.
+      // File conflict should push the higher-numbered non-serial; serial splitting
+      // then isolates the serial issue.
+      const specs = [
+        spec({ number: 1, slug: "a", ownsFiles: ["src/shared.ts"] }),
+        spec({ number: 2, slug: "b", ownsFiles: ["src/shared.ts"] }),
+        spec({ number: 3, slug: "c", serial: true }),
+      ];
+      const issues = computeWaves(specs);
+      const byNumber = new Map(issues.map((i) => [i.number, i]));
+      // #1 keeps wave 1; #2 is pushed by file conflict
+      expect(byNumber.get(1)!.wave).toBeLessThan(byNumber.get(2)!.wave);
+      // Serial issue is alone in its wave
+      const waveOf3 = byNumber.get(3)!.wave;
+      const siblingsOf3 = issues.filter((i) => i.wave === waveOf3 && i.number !== 3);
+      expect(siblingsOf3).toHaveLength(0);
+    });
+  });
 });

--- a/__tests__/yaml-schema.test.ts
+++ b/__tests__/yaml-schema.test.ts
@@ -388,4 +388,62 @@ describe("YamlConfigSchema", () => {
       }
     });
   });
+
+  describe("ownsFiles", () => {
+    it("accepts an issue with ownsFiles", () => {
+      const result = YamlConfigSchema.safeParse(
+        makeValid({
+          issues: [
+            {
+              number: 1,
+              slug: "a",
+              dependsOn: [],
+              description: "X",
+              ownsFiles: ["src/foo.ts", "src/bar.ts"],
+            },
+          ],
+        }),
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts an issue with an empty ownsFiles array", () => {
+      const result = YamlConfigSchema.safeParse(
+        makeValid({
+          issues: [
+            { number: 1, slug: "a", dependsOn: [], description: "X", ownsFiles: [] },
+          ],
+        }),
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects ownsFiles with an empty string entry", () => {
+      const result = YamlConfigSchema.safeParse(
+        makeValid({
+          issues: [
+            { number: 1, slug: "a", dependsOn: [], description: "X", ownsFiles: [""] },
+          ],
+        }),
+      );
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts a config-level sharedFiles allowlist", () => {
+      const result = YamlConfigSchema.safeParse(
+        makeValid({ sharedFiles: ["package-lock.json", "tests/mocks/db.mock.ts"] }),
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts an empty config-level sharedFiles list", () => {
+      const result = YamlConfigSchema.safeParse(makeValid({ sharedFiles: [] }));
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects sharedFiles with an empty string entry", () => {
+      const result = YamlConfigSchema.safeParse(makeValid({ sharedFiles: [""] }));
+      expect(result.success).toBe(false);
+    });
+  });
 });

--- a/src/dag.ts
+++ b/src/dag.ts
@@ -1,12 +1,27 @@
 import type { Issue, IssueSpec } from "./types.js";
 
+/** Options for `computeWaves`. */
+export interface ComputeWavesOptions {
+  /**
+   * File paths that should not trigger wave serialization when multiple issues
+   * declare ownership via `ownsFiles`. Pass the union of the config-level
+   * `sharedFiles` allowlist and `appendableFiles` paths here — those files have
+   * mechanical merge strategies and do not cause semantic conflicts.
+   */
+  ignoredOwnsFiles?: string[];
+}
+
 /**
  * Compute wave assignments from dependency declarations using topological sort.
  *
  * Issues with no dependencies get wave 1. Others get `max(wave of deps) + 1`.
+ * If `ownsFiles` is set on any issue, issues within the same candidate wave
+ * that claim an overlapping file (not covered by `ignoredOwnsFiles`) are slid
+ * to the next wave in ascending issue-number order so that the lower-numbered
+ * issue always runs first.
  * Throws if the dependency graph contains a cycle.
  */
-export function computeWaves(specs: IssueSpec[]): Issue[] {
+export function computeWaves(specs: IssueSpec[], options?: ComputeWavesOptions): Issue[] {
   if (specs.length === 0) return [];
 
   const byNumber = new Map<number, IssueSpec>();
@@ -71,13 +86,53 @@ export function computeWaves(specs: IssueSpec[]): Issue[] {
     throw new Error(`Dependency cycle detected among issues: ${inCycle}`);
   }
 
-  const issues: Issue[] = specs.map((spec) => ({
+  let issues: Issue[] = specs.map((spec) => ({
     ...spec,
     wave: waves.get(spec.number)!,
     deps: spec.dependsOn,
   }));
 
+  const ignoredFiles = new Set(options?.ignoredOwnsFiles ?? []);
+  issues = splitFileConflictWaves(issues, ignoredFiles);
   return splitSerialWaves(issues);
+}
+
+/**
+ * Post-process wave assignments so that no two issues in the same wave own an
+ * overlapping non-ignored file. Issues are processed in ascending issue-number
+ * order within each wave; the lower-numbered issue keeps its wave and the
+ * conflicting higher-numbered issue slides to the next wave. Cascades until
+ * the assignment is stable.
+ *
+ * This runs before `splitSerialWaves` so that the serial-isolation step sees
+ * the already-resolved file ownership.
+ */
+function splitFileConflictWaves(issues: Issue[], ignoredFiles: Set<string>): Issue[] {
+  if (!issues.some((i) => i.ownsFiles?.length)) return issues;
+
+  const waveOf = new Map<number, number>(issues.map((i) => [i.number, i.wave]));
+  // Upper bound: in the worst case every issue cascades to its own wave.
+  const upperBound = Math.max(...issues.map((i) => i.wave)) + issues.length;
+
+  for (let w = 1; w <= upperBound; w++) {
+    const inWave = issues
+      .filter((i) => waveOf.get(i.number) === w)
+      .sort((a, b) => a.number - b.number);
+
+    if (inWave.length === 0) continue;
+
+    const claimed = new Set<string>();
+    for (const issue of inWave) {
+      const nonIgnored = (issue.ownsFiles ?? []).filter((f) => !ignoredFiles.has(f));
+      if (nonIgnored.some((f) => claimed.has(f))) {
+        waveOf.set(issue.number, w + 1);
+      } else {
+        for (const f of nonIgnored) claimed.add(f);
+      }
+    }
+  }
+
+  return issues.map((i) => ({ ...i, wave: waveOf.get(i.number)! }));
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,9 @@ export type {
 // Engine
 export { Orchestrator, cleanUpMergedIssues } from "./engine.js";
 export { validateConfig } from "./schema.js";
+export type { ValidateConfigOptions } from "./schema.js";
 export { computeWaves } from "./dag.js";
+export type { ComputeWavesOptions } from "./dag.js";
 export { parseArgs } from "./cli.js";
 
 // Stores

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -11,6 +11,7 @@ const IssueSpecSchema = z.object({
   mode: z.string().optional(),
   stallTimeout: z.number().int().min(0).optional(),
   serial: z.boolean().optional(),
+  ownsFiles: z.array(z.string().min(1)).optional(),
 });
 
 const RawConfigSchema = z
@@ -98,14 +99,25 @@ const RawConfigSchema = z
     }
   });
 
+/** Options for `validateConfig`. */
+export interface ValidateConfigOptions {
+  /**
+   * Files to exclude when checking for `ownsFiles` conflicts across parallel
+   * issues. Combine the config-level `sharedFiles` allowlist and any
+   * `appendableFiles` paths here — the wave planner will treat overlaps on
+   * these files as safe.
+   */
+  ignoredOwnsFiles?: string[];
+}
+
 /**
  * Validate a raw orchestrator config and compute wave assignments.
  *
  * Throws a ZodError if structural, referential, or graph validation fails.
  */
-export function validateConfig(raw: RawOrchestratorConfig): OrchestratorConfig {
+export function validateConfig(raw: RawOrchestratorConfig, options?: ValidateConfigOptions): OrchestratorConfig {
   const parsed = RawConfigSchema.parse(raw);
-  const issues = computeWaves(parsed.issues);
+  const issues = computeWaves(parsed.issues, { ignoredOwnsFiles: options?.ignoredOwnsFiles });
 
   return {
     name: parsed.name,

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,13 @@ export interface IssueSpec {
    * collisions. Trades parallelism for safety on the affected issues only.
    */
   serial?: boolean;
+  /**
+   * Paths to files this issue expects to write. The wave planner uses these to
+   * detect same-file ownership conflicts across parallel issues and slides
+   * conflicting issues into later waves. Files listed in the config-level
+   * `sharedFiles` allowlist (or registered under `appendableFiles`) are exempt.
+   */
+  ownsFiles?: string[];
 }
 
 export interface Issue extends IssueSpec {

--- a/src/yaml-loader.ts
+++ b/src/yaml-loader.ts
@@ -70,18 +70,28 @@ export async function loadYamlConfig(
     ? { ...derivedHooks, ...options.hooksOverride }
     : derivedHooks;
 
+  // Files that are safe to overlap across parallel issues: explicit allowlist
+  // plus any appendableFiles paths (handled mechanically by the merge driver).
+  const ignoredOwnsFiles = [
+    ...(yaml.sharedFiles ?? []),
+    ...(yaml.appendableFiles?.map((f) => f.path) ?? []),
+  ];
+
   // Build raw config and validate (computes waves, checks graph)
-  return validateConfig({
-    name: yaml.name,
-    configDir: yaml.configDir,
-    worktreeDir: yaml.worktreeDir,
-    projectRoot: yaml.projectRoot,
-    stallTimeout: yaml.stallTimeout,
-    issues: yaml.issues,
-    hooks,
-    ...(yaml.allowedTools && { allowedTools: yaml.allowedTools }),
-    ...(yaml.issueComments && { issueComments: { repo: yaml.issueComments.repo, enabled: yaml.issueComments.enabled ?? true } }),
-    ...(yaml.labelSync && { labelSync: yaml.labelSync }),
-    ...(yaml.retryOnCheckFailure && { retryOnCheckFailure: { maxRetries: yaml.retryOnCheckFailure.maxRetries, enabled: yaml.retryOnCheckFailure.enabled ?? true } }),
-  });
+  return validateConfig(
+    {
+      name: yaml.name,
+      configDir: yaml.configDir,
+      worktreeDir: yaml.worktreeDir,
+      projectRoot: yaml.projectRoot,
+      stallTimeout: yaml.stallTimeout,
+      issues: yaml.issues,
+      hooks,
+      ...(yaml.allowedTools && { allowedTools: yaml.allowedTools }),
+      ...(yaml.issueComments && { issueComments: { repo: yaml.issueComments.repo, enabled: yaml.issueComments.enabled ?? true } }),
+      ...(yaml.labelSync && { labelSync: yaml.labelSync }),
+      ...(yaml.retryOnCheckFailure && { retryOnCheckFailure: { maxRetries: yaml.retryOnCheckFailure.maxRetries, enabled: yaml.retryOnCheckFailure.enabled ?? true } }),
+    },
+    ignoredOwnsFiles.length > 0 ? { ignoredOwnsFiles } : undefined,
+  );
 }

--- a/src/yaml-schema.ts
+++ b/src/yaml-schema.ts
@@ -9,6 +9,7 @@ const YamlIssueSchema = z.object({
   mode: z.string().optional(),
   stallTimeout: z.number().int().min(0).optional(),
   serial: z.boolean().optional(),
+  ownsFiles: z.array(z.string().min(1)).optional(),
 });
 
 const YamlSummaryColumnSchema = z.object({
@@ -88,6 +89,7 @@ export const YamlConfigSchema = z.object({
   baseBranch: z.string().min(1).optional(),
   sequentialPaths: z.array(SequentialPathConfigSchema).optional(),
   appendableFiles: z.array(AppendableFileSpecSchema).optional(),
+  sharedFiles: z.array(z.string().min(1)).optional(),
   sequentialDomains: z
     .record(
       z

--- a/src/yaml-types.ts
+++ b/src/yaml-types.ts
@@ -74,6 +74,8 @@ export interface YamlIssue {
   stallTimeout?: number;
   /** Run this issue alone in its own wave. See `IssueSpec.serial`. */
   serial?: boolean;
+  /** Paths to files this issue expects to write. See `IssueSpec.ownsFiles`. */
+  ownsFiles?: string[];
 }
 
 /**
@@ -124,6 +126,13 @@ export interface YamlConfig {
    * for setup instructions.
    */
   appendableFiles?: AppendableFileSpec[];
+  /**
+   * Files that are safe to overlap across parallel issues and should not
+   * trigger wave serialization by the ownsFiles conflict detector. Typical
+   * entries: `package-lock.json`, test mocks, append-style JSON files already
+   * covered by the journal merge driver.
+   */
+  sharedFiles?: string[];
   issues: YamlIssue[];
 }
 


### PR DESCRIPTION
## Summary

- Adds `ownsFiles` field to issue configs so operators can declare which files each issue expects to touch
- Adds `sharedFiles` config-level allowlist for files safe to overlap across parallel issues (e.g. `package-lock.json`, mocks); `appendableFiles` paths are automatically exempt since the journal merge driver handles them
- Extends `computeWaves()` with a greedy forward pass that slides the higher-numbered conflicting issue into the next wave when two issues in the same candidate wave claim an overlapping non-shared file

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm test` passes (586 tests, including new dag and yaml-schema tests for all new behavior and edge cases)
- [ ] Two issues with the same ownsFiles entry land in separate waves
- [ ] Issues sharing only allowlisted files remain in the same wave
- [ ] Cascade: three issues claiming the same file each get their own wave
- [ ] Interacts correctly with `serial` flag (file conflict detection runs before serial isolation)

Closes #39