### PR TITLE
migrate git execSync calls to execFileSync array form

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,23 @@
+# HANDOFF: execFileSync migration (issue #36)
+
+## What changed
+
+### Public API changes
+- `SeedFromGitDeps.runCommand` (exported from `src/index.ts`) signature changed from `(cmd: string) => string` to `(file: string, args: string[]) => string`. The first argument is the program name (`"git"`), the second is the argument array.
+
+### Internal changes
+- `GatherCollisionInputsDeps.runCommand` in `src/collision-check.ts` — same signature change.
+- `src/cli-claim.ts` — CLI entry point now uses `execFileSync` instead of `execSync` when invoking `seedFromGit`.
+- `src/yaml-hooks.ts` — `DeriveHooksDeps` gained an optional `runGitCommand?: (file: string, args: string[]) => string` field. When present, it is used for all git calls inside `gatherCollisionInputs`. When absent, defaults to `execFileSync`. The existing `runCommand?: (cmd: string, cwd: string) => string` field is unchanged and still used for shell commands (npm test, etc.).
+- `src/shell-quote.ts` retained — still used by `github.ts`, `create-main.ts`, and `buildClaimCommand` in `yaml-hooks.ts` (agent-targeted shell strings).
+
+## Decisions / contracts the next issue should know
+
+- Any code that constructs a `SeedFromGitDeps` or `GatherCollisionInputsDeps` (real or mock) must now pass `(file, args)` — a `(cmd: string) => ...` function will fail TypeScript.
+- The real implementation in `cli-claim.ts` calls `execFileSync(file, args, { encoding: "utf-8" })`. No shell is involved; path components (spaces, `$`, quotes) are passed through unchanged.
+- The `runGitCommand` DI in `DeriveHooksDeps` follows the same `(file, args)` contract. Tests that previously passed `runCommand` for git assertions should now pass `runGitCommand`.
+
+## Caveats
+
+- `SeedFromGitDeps` is exported from `src/index.ts`. Downstream consumers of the npm package that build a `SeedFromGitDeps` object directly will need to update their `runCommand` signature.
+- The `runGitCommand` field is new and optional in `DeriveHooksDeps`. Existing callers that pass neither field will get the real `execFileSync` for git calls — correct for production, but tests that relied on the old `runCommand` mock being called for git would silently stop intercepting those calls. Check any `yaml-hooks` consumer tests that count `runCommand` invocations.

--- a/__tests__/collision-check.test.ts
+++ b/__tests__/collision-check.test.ts
@@ -199,19 +199,21 @@ describe("gatherCollisionInputs", () => {
       baseBranch: "main",
     });
     const fetchCall = runCommand.mock.calls.find(
-      ([cmd]) =>
-        cmd.includes("/tmp/wt/foo") &&
-        cmd.includes("fetch origin") &&
-        cmd.includes("main"),
+      ([file, args]) =>
+        file === "git" &&
+        args.includes("-C") &&
+        args.includes("/tmp/wt/foo") &&
+        args.includes("fetch") &&
+        args.includes("origin") &&
+        args.includes("main"),
     );
     expect(fetchCall).toBeDefined();
   });
 
   it("collects current's added files via diff against merge-base..HEAD", () => {
-    const runCommand = vi.fn((cmd: string) => {
-      if (cmd.includes("merge-base HEAD") && cmd.includes("origin/main"))
-        return "abc123\n";
-      if (cmd.includes("diff") && cmd.includes("abc123..HEAD")) {
+    const runCommand = vi.fn((file: string, args: string[]) => {
+      if (args.includes("merge-base") && args.includes("HEAD")) return "abc123\n";
+      if (args.includes("diff") && args.some((a) => a === "abc123..HEAD")) {
         return "migrations/0056_add_x.sql\nmigrations/README.md\n";
       }
       return "";
@@ -243,8 +245,8 @@ describe("gatherCollisionInputs", () => {
   });
 
   it("treats a peer with a broken git invocation as no-info, not fatal", () => {
-    const runCommand = vi.fn((cmd: string) => {
-      if (cmd.includes("/tmp/wt/bar")) throw new Error("not a git repository");
+    const runCommand = vi.fn((file: string, args: string[]) => {
+      if (args.includes("/tmp/wt/bar")) throw new Error("not a git repository");
       return "";
     });
     const result = gatherCollisionInputs({
@@ -258,8 +260,12 @@ describe("gatherCollisionInputs", () => {
     expect(result.peers).toEqual({ bar: {} });
   });
 
-  it("shell-quotes worktree paths, refs, and entry dirs so spaces and metas are safe", () => {
-    const runCommand = vi.fn().mockReturnValue("");
+  it("passes worktree paths, refs, and entry dirs as raw unquoted arguments", () => {
+    const runCommand = vi.fn((_file: string, args: string[]) => {
+      // Return a commit hash for merge-base so collectAddedByEntry runs
+      if (args.includes("merge-base")) return "abc123\n";
+      return "";
+    });
     gatherCollisionInputs({
       runCommand,
       existsSync: () => true,
@@ -268,21 +274,19 @@ describe("gatherCollisionInputs", () => {
       entries: [{ dir: "weird dir/$X", pattern: "(\\d+)" }],
       baseBranch: "feat/branch",
     });
-    const cmds = runCommand.mock.calls.map((c) => c[0] as string);
-    // Every call must wrap the worktree path, branch ref, and entry dir in
-    // single quotes so the shell passes them as one argument each.
-    expect(cmds.some((c) => c.includes(`'/tmp/with space'`))).toBe(true);
-    expect(cmds.some((c) => c.includes(`'/tmp/peer'\\''s path'`))).toBe(true);
-    expect(cmds.some((c) => c.includes(`'feat/branch'`))).toBe(true);
-    expect(cmds.some((c) => c.includes(`'origin/feat/branch'`))).toBe(true);
+    const calls = runCommand.mock.calls as [string, string[]][];
+    expect(calls.some(([, args]) => args.includes("/tmp/with space"))).toBe(true);
+    expect(calls.some(([, args]) => args.includes("/tmp/peer's path"))).toBe(true);
+    expect(calls.some(([, args]) => args.includes("feat/branch"))).toBe(true);
+    expect(calls.some(([, args]) => args.includes("origin/feat/branch"))).toBe(true);
+    expect(calls.some(([, args]) => args.includes("weird dir/$X"))).toBe(true);
   });
 
   it("collects shipped (origin since merge-base) added files in current worktree", () => {
-    const runCommand = vi.fn((cmd: string) => {
-      if (cmd.includes("merge-base HEAD") && cmd.includes("origin/main"))
-        return "abc123\n";
-      if (cmd.includes("abc123..HEAD")) return "";
-      if (cmd.includes("abc123..origin/main")) {
+    const runCommand = vi.fn((file: string, args: string[]) => {
+      if (args.includes("merge-base") && args.includes("HEAD")) return "abc123\n";
+      if (args.some((a) => a === "abc123..HEAD")) return "";
+      if (args.some((a) => a === "abc123..origin/main")) {
         return "migrations/0056_shipped.sql\n";
       }
       return "";

--- a/__tests__/seed-from-git.test.ts
+++ b/__tests__/seed-from-git.test.ts
@@ -85,9 +85,11 @@ describe("seedFromGit", () => {
         paths: [{ dir: "migrations", pattern: "(\\d{4})_.*\\.sql" }],
       },
     );
-    const cmd = runCommand.mock.calls[0]![0];
-    expect(cmd).toContain("fetch origin");
-    expect(cmd).toContain("main");
+    const [file, args] = runCommand.mock.calls[0]!;
+    expect(file).toBe("git");
+    expect(args).toContain("fetch");
+    expect(args).toContain("origin");
+    expect(args).toContain("main");
   });
 
   it("continues scanning when the fetch fails", () => {
@@ -123,7 +125,7 @@ describe("seedFromGit", () => {
     expect(next).toBe(1);
   });
 
-  it("shell-quotes repo dir, branch, and per-path dir so spaces and metas are safe", () => {
+  it("passes repo dir, branch, and per-path dir as raw unquoted arguments", () => {
     const runCommand = vi.fn().mockReturnValue("");
     seedFromGit(
       { runCommand },
@@ -133,11 +135,11 @@ describe("seedFromGit", () => {
         paths: [{ dir: "weird dir/$X", pattern: "(\\d{4})" }],
       },
     );
-    const cmds = runCommand.mock.calls.map((c) => c[0] as string);
-    expect(cmds.some((c) => c.includes(`'/tmp/with space'`))).toBe(true);
-    expect(cmds.some((c) => c.includes(`'feat/branch'`))).toBe(true);
-    expect(cmds.some((c) => c.includes(`'origin/feat/branch'`))).toBe(true);
-    expect(cmds.some((c) => c.includes(`'weird dir/$X'`))).toBe(true);
+    const calls = runCommand.mock.calls as [string, string[]][];
+    expect(calls.some(([, args]) => args.includes("/tmp/with space"))).toBe(true);
+    expect(calls.some(([, args]) => args.includes("feat/branch"))).toBe(true);
+    expect(calls.some(([, args]) => args.includes("origin/feat/branch"))).toBe(true);
+    expect(calls.some(([, args]) => args.includes("weird dir/$X"))).toBe(true);
   });
 
   it("uses the configured base branch", () => {
@@ -150,8 +152,8 @@ describe("seedFromGit", () => {
         paths: [{ dir: "migrations", pattern: "(\\d{4})_.*\\.sql" }],
       },
     );
-    const lsTreeCmd = runCommand.mock.calls[1]![0];
-    expect(lsTreeCmd).toContain("origin/develop");
+    const [, lsTreeArgs] = runCommand.mock.calls[1]!;
+    expect(lsTreeArgs).toContain("origin/develop");
   });
 });
 

--- a/__tests__/yaml-hooks.test.ts
+++ b/__tests__/yaml-hooks.test.ts
@@ -330,21 +330,20 @@ describe("deriveHooks", () => {
       barAdded?: string[];
       shippedAdded?: string[];
       barExists?: boolean;
-    } = {}): { runCommand: ReturnType<typeof vi.fn>; existsSync: ReturnType<typeof vi.fn> } {
-      const runCommand = vi.fn((cmd: string) => {
-        if (cmd.includes("fetch origin")) return "";
-        if (cmd.includes("merge-base HEAD") && cmd.includes("origin/main"))
-          return "abc123\n";
+    } = {}): { runGitCommand: ReturnType<typeof vi.fn>; existsSync: ReturnType<typeof vi.fn> } {
+      const runGitCommand = vi.fn((file: string, args: string[]) => {
+        if (args.includes("fetch")) return "";
+        if (args.includes("merge-base") && args.includes("HEAD")) return "abc123\n";
         // current worktree: abc123..HEAD
-        if (cmd.includes("/tmp/worktrees/foo") && cmd.includes("abc123..HEAD")) {
+        if (args.includes("/tmp/worktrees/foo") && args.some((a) => a === "abc123..HEAD")) {
           return (opts.currentAdded ?? []).join("\n") + "\n";
         }
         // current worktree: abc123..origin/main (shipped)
-        if (cmd.includes("/tmp/worktrees/foo") && cmd.includes("abc123..origin/main")) {
+        if (args.includes("/tmp/worktrees/foo") && args.some((a) => a === "abc123..origin/main")) {
           return (opts.shippedAdded ?? []).join("\n") + "\n";
         }
         // peer bar: abc123..HEAD
-        if (cmd.includes("/tmp/worktrees/bar") && cmd.includes("abc123..HEAD")) {
+        if (args.includes("/tmp/worktrees/bar") && args.some((a) => a === "abc123..HEAD")) {
           return (opts.barAdded ?? []).join("\n") + "\n";
         }
         return "";
@@ -353,11 +352,11 @@ describe("deriveHooks", () => {
         if (p === "/tmp/worktrees/bar") return opts.barExists ?? true;
         return false;
       });
-      return { runCommand, existsSync };
+      return { runGitCommand, existsSync };
     }
 
     it("passes when no peer worktrees exist", async () => {
-      const { runCommand, existsSync } = setUpCollisionMocks({
+      const { runGitCommand, existsSync } = setUpCollisionMocks({
         currentAdded: ["migrations/0056_a.sql"],
         barExists: false,
       });
@@ -365,7 +364,7 @@ describe("deriveHooks", () => {
         makeYaml({
           sequentialPaths: [{ dir: "migrations", pattern: "(\\d{4})_.*\\.sql" }],
         }),
-        { runCommand, existsSync },
+        { runGitCommand, existsSync },
       );
       const issue = makeIssue({ slug: "foo" });
       const result = await hooks.postSessionCheck!(issue, "/tmp/worktrees/foo");
@@ -373,7 +372,7 @@ describe("deriveHooks", () => {
     });
 
     it("fails when a peer worktree added a colliding key", async () => {
-      const { runCommand, existsSync } = setUpCollisionMocks({
+      const { runGitCommand, existsSync } = setUpCollisionMocks({
         currentAdded: ["migrations/0056_a.sql"],
         barAdded: ["migrations/0056_b.sql"],
       });
@@ -381,7 +380,7 @@ describe("deriveHooks", () => {
         makeYaml({
           sequentialPaths: [{ dir: "migrations", pattern: "(\\d{4})_.*\\.sql" }],
         }),
-        { runCommand, existsSync },
+        { runGitCommand, existsSync },
       );
       const result = await hooks.postSessionCheck!(
         makeIssue({ slug: "foo" }),
@@ -394,7 +393,7 @@ describe("deriveHooks", () => {
     });
 
     it("fails when origin/main shipped a colliding key since the merge-base", async () => {
-      const { runCommand, existsSync } = setUpCollisionMocks({
+      const { runGitCommand, existsSync } = setUpCollisionMocks({
         currentAdded: ["migrations/0056_a.sql"],
         shippedAdded: ["migrations/0056_shipped.sql"],
         barExists: false,
@@ -403,7 +402,7 @@ describe("deriveHooks", () => {
         makeYaml({
           sequentialPaths: [{ dir: "migrations", pattern: "(\\d{4})_.*\\.sql" }],
         }),
-        { runCommand, existsSync },
+        { runGitCommand, existsSync },
       );
       const result = await hooks.postSessionCheck!(
         makeIssue({ slug: "foo" }),
@@ -415,21 +414,20 @@ describe("deriveHooks", () => {
 
     it("logs a warning and continues when a peer's git invocation throws", async () => {
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-      const runCommand = vi.fn((cmd: string) => {
-        if (cmd.includes("fetch origin")) return "";
-        if (cmd.includes("/tmp/worktrees/bar")) {
+      const runGitCommand = vi.fn((file: string, args: string[]) => {
+        if (args.includes("fetch")) return "";
+        if (args.includes("/tmp/worktrees/bar")) {
           throw new Error("not a git repository");
         }
-        if (cmd.includes("merge-base HEAD") && cmd.includes("origin/main"))
-          return "abc123\n";
-        if (cmd.includes("abc123..HEAD")) return "migrations/0056_a.sql\n";
+        if (args.includes("merge-base") && args.includes("HEAD")) return "abc123\n";
+        if (args.some((a) => a === "abc123..HEAD")) return "migrations/0056_a.sql\n";
         return "";
       });
       const hooks = deriveHooks(
         makeYaml({
           sequentialPaths: [{ dir: "migrations", pattern: "(\\d{4})_.*\\.sql" }],
         }),
-        { runCommand, existsSync: () => true },
+        { runGitCommand, existsSync: () => true },
       );
       const result = await hooks.postSessionCheck!(
         makeIssue({ slug: "foo" }),
@@ -465,23 +463,23 @@ describe("deriveHooks", () => {
     });
 
     it("uses configured baseBranch when provided", async () => {
-      const runCommand = vi.fn().mockReturnValue("");
+      const runGitCommand = vi.fn().mockReturnValue("");
       const hooks = deriveHooks(
         makeYaml({
           baseBranch: "trunk",
           sequentialPaths: [{ dir: "migrations", pattern: "(\\d{4})_.*\\.sql" }],
         }),
-        { runCommand, existsSync: () => false },
+        { runGitCommand, existsSync: () => false },
       );
       await hooks.postSessionCheck!(
         makeIssue({ slug: "foo" }),
         "/tmp/worktrees/foo",
       );
-      const fetchCall = runCommand.mock.calls.find(
-        ([cmd]) => cmd.includes("fetch origin") && cmd.includes("trunk"),
+      const fetchCall = (runGitCommand.mock.calls as [string, string[]][]).find(
+        ([file, args]) => file === "git" && args.includes("fetch") && args.includes("trunk"),
       );
       expect(fetchCall).toBeDefined();
-      expect(fetchCall![1]).toBe("/tmp/worktrees/foo");
+      expect(fetchCall![1]).toContain("/tmp/worktrees/foo");
     });
   });
 

--- a/src/cli-claim.ts
+++ b/src/cli-claim.ts
@@ -11,7 +11,7 @@
  * file's bottom is the CLI entry-point that wires real I/O.
  */
 
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -137,7 +137,7 @@ function main(): void {
   const store = new FileCounterStore(yaml.configDir);
   const seed = (): number =>
     seedFromGit(
-      { runCommand: (cmd: string) => execSync(cmd, { encoding: "utf-8" }) },
+      { runCommand: (file: string, args: string[]) => execFileSync(file, args, { encoding: "utf-8" }) },
       {
         repoDir: yaml.projectRoot,
         baseBranch,

--- a/src/collision-check.ts
+++ b/src/collision-check.ts
@@ -8,8 +8,6 @@
  * applies the per-entry regex to produce the structured input.
  */
 
-import { shellQuote } from "./shell-quote.js";
-
 export interface SequentialPathEntry {
   /** Directory relative to the worktree root. */
   dir: string;
@@ -185,7 +183,7 @@ function renderOutput(
 // ---------------------------------------------------------------------------
 
 export interface GatherCollisionInputsDeps {
-  runCommand: (cmd: string) => string;
+  runCommand: (file: string, args: string[]) => string;
   existsSync: (path: string) => boolean;
   currentWorktree: string;
   peers: { slug: string; worktreePath: string }[];
@@ -203,9 +201,7 @@ export function gatherCollisionInputs(
 
   // Best-effort fetch — never fail the scan because origin is unreachable.
   try {
-    runCommand(
-      `git -C ${shellQuote(currentWorktree)} fetch origin ${shellQuote(baseBranch)}`,
-    );
+    runCommand("git", ["-C", currentWorktree, "fetch", "origin", baseBranch]);
   } catch {
     // ignore — we proceed with whatever origin/<baseBranch> currently points to
   }
@@ -234,7 +230,7 @@ export function gatherCollisionInputs(
     if (!existsSync(peer.worktreePath)) continue;
     try {
       const peerBase = runCommand(
-        `git -C ${shellQuote(peer.worktreePath)} merge-base HEAD ${shellQuote(`origin/${baseBranch}`)}`,
+        "git", ["-C", peer.worktreePath, "merge-base", "HEAD", `origin/${baseBranch}`],
       ).trim();
       if (!peerBase) {
         peersOut[peer.slug] = {};
@@ -257,13 +253,13 @@ export function gatherCollisionInputs(
 }
 
 function safeMergeBase(
-  runCommand: (cmd: string) => string,
+  runCommand: (file: string, args: string[]) => string,
   worktree: string,
   baseBranch: string,
 ): string | null {
   try {
     const out = runCommand(
-      `git -C ${shellQuote(worktree)} merge-base HEAD ${shellQuote(`origin/${baseBranch}`)}`,
+      "git", ["-C", worktree, "merge-base", "HEAD", `origin/${baseBranch}`],
     );
     const sha = out.trim();
     return sha.length > 0 ? sha : null;
@@ -273,7 +269,7 @@ function safeMergeBase(
 }
 
 function collectAddedByEntry(
-  runCommand: (cmd: string) => string,
+  runCommand: (file: string, args: string[]) => string,
   worktree: string,
   range: string,
   compiled: { entry: SequentialPathEntry; regex: RegExp }[],
@@ -285,7 +281,7 @@ function collectAddedByEntry(
     let raw: string;
     try {
       raw = runCommand(
-        `git -C ${shellQuote(worktree)} diff --diff-filter=A --find-renames --name-only ${shellQuote(range)} -- ${shellQuote(entry.dir)}`,
+        "git", ["-C", worktree, "diff", "--diff-filter=A", "--find-renames", "--name-only", range, "--", entry.dir],
       );
     } catch (err) {
       if (throwOnError) throw err;

--- a/src/seed-from-git.ts
+++ b/src/seed-from-git.ts
@@ -7,10 +7,8 @@
  * the assumption is that a fresh project legitimately has no migrations yet.
  */
 
-import { shellQuote } from "./shell-quote.js";
-
 export interface SeedFromGitDeps {
-  runCommand: (cmd: string) => string;
+  runCommand: (file: string, args: string[]) => string;
 }
 
 export interface SeedFromGitOptions {
@@ -28,9 +26,7 @@ export function seedFromGit(
   // origin doesn't block claims (we proceed with whatever ref currently
   // points to).
   try {
-    deps.runCommand(
-      `git -C ${shellQuote(options.repoDir)} fetch origin ${shellQuote(options.baseBranch)}`,
-    );
+    deps.runCommand("git", ["-C", options.repoDir, "fetch", "origin", options.baseBranch]);
   } catch {
     // ignore
   }
@@ -40,9 +36,12 @@ export function seedFromGit(
     const re = new RegExp(pattern);
     let raw: string;
     try {
-      raw = deps.runCommand(
-        `git -C ${shellQuote(options.repoDir)} ls-tree -r --name-only ${shellQuote(`origin/${options.baseBranch}`)} -- ${shellQuote(dir)}`,
-      );
+      raw = deps.runCommand("git", [
+        "-C", options.repoDir,
+        "ls-tree", "-r", "--name-only",
+        `origin/${options.baseBranch}`,
+        "--", dir,
+      ]);
     } catch {
       continue;
     }

--- a/src/yaml-hooks.ts
+++ b/src/yaml-hooks.ts
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import { existsSync as fsExistsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -14,6 +14,11 @@ import { shellQuote } from "./shell-quote.js";
 export interface DeriveHooksDeps {
   readFile?: (path: string) => string;
   runCommand?: (cmd: string, cwd: string) => string;
+  /**
+   * Used by collision detection to run git commands with an argument array
+   * (avoids shell quoting entirely). Defaults to `execFileSync`.
+   */
+  runGitCommand?: (file: string, args: string[]) => string;
   /**
    * Used by collision detection to check whether a peer's worktree directory
    * is present on disk. Defaults to `node:fs.existsSync`.
@@ -259,7 +264,8 @@ export function deriveHooks(
           }));
 
         const exists = deps.existsSync ?? fsExistsSync;
-        const gitRun = (cmd: string): string => run(cmd, worktreePath);
+        const gitRun: (file: string, args: string[]) => string =
+          deps.runGitCommand ?? ((file, args) => execFileSync(file, args, { encoding: "utf-8" }));
 
         const collisionInput = gatherCollisionInputs({
           runCommand: gitRun,


### PR DESCRIPTION
## Summary
- Replace `runCommand: (cmd: string) => string` with `(file: string, args: string[]) => string` in `collision-check.ts`, `seed-from-git.ts`, and `cli-claim.ts`'s seed path — git arguments are now passed as arrays to `execFileSync`, eliminating the shell-injection class at the source
- Add `runGitCommand` DI hook to `DeriveHooksDeps` in `yaml-hooks.ts` so tests can inject a typed mock separate from the shell-command `runCommand` path
- `shell-quote.ts` is retained: `github.ts`, `create-main.ts`, and `buildClaimCommand` in `yaml-hooks.ts` still emit agent-targeted shell strings that genuinely require quoting

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes (586 tests)
- [x] Test mocks updated to assert on argument arrays instead of substring matching
- [x] "shell-quotes" tests replaced with "passes raw unquoted arguments" tests

Closes #36