### PR TITLE
reconcile claim counter against origin/<baseBranch> on every allocation

### DIFF
--- a/__tests__/cli-claim.test.ts
+++ b/__tests__/cli-claim.test.ts
@@ -167,7 +167,7 @@ describe("runClaim", () => {
     expect(result).toEqual({ number: 57, formatted: "0057" });
   });
 
-  it("increments across distinct issues in the same domain", () => {
+  it("increments across distinct issues when origin is unchanged", () => {
     const store = new InMemoryCounterStore();
     runClaim({
       yaml: baseYaml(),
@@ -181,9 +181,29 @@ describe("runClaim", () => {
       issue: 2,
       domain: "migrations",
       store,
-      seed: () => 999,
+      seed: () => 57,
     });
     expect(result).toEqual({ number: 58, formatted: "0058" });
+  });
+
+  it("reconciles with origin when origin has advanced past the persisted counter", () => {
+    const store = new InMemoryCounterStore();
+    runClaim({
+      yaml: baseYaml(),
+      issue: 1,
+      domain: "migrations",
+      store,
+      seed: () => 57,
+    });
+    // External file 0070_*.sql landed on origin; seed now returns 71
+    const result = runClaim({
+      yaml: baseYaml(),
+      issue: 2,
+      domain: "migrations",
+      store,
+      seed: () => 71,
+    });
+    expect(result).toEqual({ number: 71, formatted: "0071" });
   });
 
   it("returns the same number on a retry of the same issue", () => {

--- a/__tests__/counter-store.test.ts
+++ b/__tests__/counter-store.test.ts
@@ -19,9 +19,10 @@ describe("InMemoryCounterStore", () => {
     expect(store.claim("migrations", 1, () => 56)).toBe(56);
   });
 
-  it("increments for the next distinct issue", () => {
+  it("increments for the next distinct issue when origin is unchanged", () => {
     store.claim("migrations", 1, () => 56);
-    expect(store.claim("migrations", 2, () => 999)).toBe(57);
+    // seed returns 56 — origin still shows 55 as max, so externalFloor=56 ≤ persisted 57
+    expect(store.claim("migrations", 2, () => 56)).toBe(57);
   });
 
   it("returns the same number on a repeat claim from the same issue", () => {
@@ -30,16 +31,25 @@ describe("InMemoryCounterStore", () => {
     expect(second).toBe(first);
   });
 
-  it("does not call the seed function on subsequent claims", () => {
+  it("calls seed on each new-issue allocation but not on retries", () => {
     let seedCalls = 0;
     const seed = () => {
       seedCalls++;
       return 56;
     };
-    store.claim("migrations", 1, seed);
-    store.claim("migrations", 2, seed);
-    store.claim("migrations", 3, seed);
-    expect(seedCalls).toBe(1);
+    store.claim("migrations", 1, seed); // new (null state) — calls seed
+    store.claim("migrations", 2, seed); // new issue — calls seed
+    store.claim("migrations", 3, seed); // new issue — calls seed
+    store.claim("migrations", 1, seed); // retry — does NOT call seed
+    expect(seedCalls).toBe(3);
+  });
+
+  it("bumps the counter when origin has advanced past persisted state", () => {
+    store.claim("migrations", 1, () => 56); // next becomes 57
+    // External files landed; seed now returns 71 (origin max is 70)
+    expect(store.claim("migrations", 2, () => 71)).toBe(71);
+    // Counter advances past the external floor
+    expect(store.claim("migrations", 3, () => 71)).toBe(72);
   });
 
   it("tracks domains independently", () => {
@@ -69,9 +79,9 @@ describe("FileCounterStore", () => {
     expect(state.claims["1"]).toBe(56);
   });
 
-  it("increments across distinct issues", () => {
+  it("increments across distinct issues when origin is unchanged", () => {
     store.claim("migrations", 1, () => 56);
-    expect(store.claim("migrations", 2, () => 999)).toBe(57);
+    expect(store.claim("migrations", 2, () => 56)).toBe(57);
   });
 
   it("returns the same number on retry of the same issue", () => {
@@ -83,7 +93,7 @@ describe("FileCounterStore", () => {
   it("survives a restart (new store instance reads existing file)", () => {
     store.claim("migrations", 1, () => 56);
     const fresh = new FileCounterStore(tmpDir);
-    expect(fresh.claim("migrations", 2, () => 999)).toBe(57);
+    expect(fresh.claim("migrations", 2, () => 56)).toBe(57);
   });
 
   it("creates the counters directory if missing", () => {

--- a/src/counter-store.ts
+++ b/src/counter-store.ts
@@ -20,8 +20,12 @@ export interface CounterStore {
    * Atomically claim the next number for `domain` on behalf of `issueNumber`.
    *
    * Idempotent: a second call with the same `(domain, issueNumber)` returns
-   * the previously-claimed number. `seed` is consulted only when the domain
-   * has no recorded state — its return value becomes the first issued number.
+   * the previously-claimed number without invoking `seed`.
+   *
+   * For every *new* allocation, `seed` is called and its return value is used
+   * as a floor: `Math.max(persisted.next, seed())`. This reconciles the
+   * counter against external state (e.g. `origin/<baseBranch>`) so claims
+   * remain collision-free even when files land outside the orchestrator run.
    *
    * Returns the raw integer; formatting (zero-padding for display) is the
    * caller's concern since width is a presentation choice tied to the
@@ -40,22 +44,22 @@ function applyClaim(
   issueNumber: number,
   seed: () => number,
 ): { state: DomainState; number: number } {
-  if (state === null) {
-    const seeded = seed();
-    return {
-      state: { next: seeded + 1, claims: { [String(issueNumber)]: seeded } },
-      number: seeded,
-    };
-  }
-  const existing = state.claims[String(issueNumber)];
+  // Idempotent retry: return the previously recorded claim unchanged.
+  const existing = state?.claims[String(issueNumber)];
   if (existing !== undefined) {
-    return { state, number: existing };
+    return { state: state!, number: existing };
   }
-  const issued = state.next;
+
+  // New allocation: scan origin/<baseBranch> on every claim so the counter
+  // stays ahead of externally-landed sequential files (issue #38). seed()
+  // returns externalMax + 1; Math.max ensures the persisted counter is never
+  // rolled back if origin hasn't advanced.
+  const externalFloor = seed();
+  const issued = state === null ? externalFloor : Math.max(state.next, externalFloor);
   return {
     state: {
       next: issued + 1,
-      claims: { ...state.claims, [String(issueNumber)]: issued },
+      claims: { ...(state?.claims ?? {}), [String(issueNumber)]: issued },
     },
     number: issued,
   };


### PR DESCRIPTION
## Summary

- `applyClaim` in `counter-store.ts` previously called `seed()` only when a domain had no persisted state (null), meaning claims issued after the first could collide with files that landed on `origin/<baseBranch>` from outside the orchestrator
- `applyClaim` now calls `seed()` for every *new* allocation and uses `Math.max(persisted.next, seed())` as the issued number, so the counter stays ahead of whatever `origin` shows at claim time
- Idempotent retries of an existing `(domain, issueNumber)` pair still return the recorded number without invoking `seed`

## Test plan

- [ ] `InMemoryCounterStore` — new test "bumps the counter when origin has advanced past persisted state" verifies the reconcile path
- [ ] `InMemoryCounterStore` — updated "calls seed on each new-issue allocation but not on retries" verifies seed is invoked per new issue, not per retry
- [ ] `cli-claim` — new test "reconciles with origin when origin has advanced past the persisted counter" exercises the full `runClaim` path
- [ ] All 588 existing tests continue to pass

Closes #38