### PR TITLE
fix: route --detach respawn through tsx for TypeScript entry points

### DIFF
--- a/__tests__/create-main.test.ts
+++ b/__tests__/create-main.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import {
+  buildDetachSpawnCommand,
   buildGhIssueCreateCommand,
   buildNotificationScript,
+  findScriptPackageRoot,
 } from "../src/create-main.js";
 
 describe("buildGhIssueCreateCommand", () => {
@@ -54,5 +59,179 @@ describe("buildNotificationScript", () => {
     expect(buildNotificationScript("$`'", "0 succeeded, 1 failed")).toBe(
       "display notification \"0 succeeded, 1 failed\" with title \"$`'\"",
     );
+  });
+});
+
+describe("buildDetachSpawnCommand", () => {
+  // The detach respawn runs in a fresh process. When the consumer's entry
+  // point is a TypeScript file, plain `node` will fail to resolve `.js`
+  // imports that point at `.ts` files. Route through `npx tsx` so the
+  // consumer's tsx (declared in its node_modules) handles loader duties.
+  // Compiled `.js` consumers stay on `node` so they don't pay the npx
+  // round-trip on every detach.
+
+  const NODE = "/usr/bin/node";
+
+  it("uses node directly for compiled .js script paths", () => {
+    expect(
+      buildDetachSpawnCommand({
+        scriptPath: "/repo/dist/main.js",
+        configName: "my-config",
+        childArgv: ["--parallel", "4"],
+        nodeExecPath: NODE,
+        findPackageRoot: () => "/repo",
+      }),
+    ).toEqual({
+      command: NODE,
+      args: ["/repo/dist/main.js", "my-config", "--parallel", "4"],
+    });
+  });
+
+  it("routes .ts script paths through `npx --prefix <pkgRoot> tsx`", () => {
+    expect(
+      buildDetachSpawnCommand({
+        scriptPath: "/repo/scripts/orchestrator/src/main.ts",
+        configName: "ios-wave-2c",
+        childArgv: ["--parallel", "4", "--notify"],
+        nodeExecPath: NODE,
+        findPackageRoot: () => "/repo/scripts/orchestrator",
+      }),
+    ).toEqual({
+      command: "npx",
+      args: [
+        "--prefix",
+        "/repo/scripts/orchestrator",
+        "tsx",
+        "/repo/scripts/orchestrator/src/main.ts",
+        "ios-wave-2c",
+        "--parallel",
+        "4",
+        "--notify",
+      ],
+    });
+  });
+
+  it.each([".ts", ".mts", ".cts", ".tsx"])(
+    "treats %s as TypeScript",
+    (ext) => {
+      const result = buildDetachSpawnCommand({
+        scriptPath: `/repo/main${ext}`,
+        configName: "c",
+        childArgv: [],
+        nodeExecPath: NODE,
+        findPackageRoot: () => "/repo",
+      });
+      expect(result.command).toBe("npx");
+      expect(result.args).toContain("tsx");
+    },
+  );
+
+  it.each([".js", ".mjs", ".cjs"])(
+    "treats %s as plain JavaScript",
+    (ext) => {
+      const result = buildDetachSpawnCommand({
+        scriptPath: `/repo/main${ext}`,
+        configName: "c",
+        childArgv: [],
+        nodeExecPath: NODE,
+        findPackageRoot: () => "/repo",
+      });
+      expect(result.command).toBe(NODE);
+      expect(result.args[0]).toBe(`/repo/main${ext}`);
+    },
+  );
+
+  it("omits --prefix when no package root is found (npx falls back to cwd resolution)", () => {
+    expect(
+      buildDetachSpawnCommand({
+        scriptPath: "/tmp/scratch.ts",
+        configName: "c",
+        childArgv: [],
+        nodeExecPath: NODE,
+        findPackageRoot: () => null,
+      }),
+    ).toEqual({
+      command: "npx",
+      args: ["tsx", "/tmp/scratch.ts", "c"],
+    });
+  });
+
+  it("passes through all childArgv tokens verbatim", () => {
+    const result = buildDetachSpawnCommand({
+      scriptPath: "/r/m.ts",
+      configName: "c",
+      childArgv: ["--parallel", "4", "--notify", "--wave", "2"],
+      nodeExecPath: NODE,
+      findPackageRoot: () => "/r",
+    });
+    expect(result.args.slice(-5)).toEqual([
+      "--parallel",
+      "4",
+      "--notify",
+      "--wave",
+      "2",
+    ]);
+  });
+
+  it("recognizes TypeScript regardless of extension case (TS, MTS, etc.)", () => {
+    const result = buildDetachSpawnCommand({
+      scriptPath: "/r/Main.TS",
+      configName: "c",
+      childArgv: [],
+      nodeExecPath: NODE,
+      findPackageRoot: () => "/r",
+    });
+    expect(result.command).toBe("npx");
+  });
+});
+
+describe("findScriptPackageRoot", () => {
+  // Walks up from the script's directory toward the filesystem root, returning
+  // the first ancestor with a package.json. Used by --detach to pin
+  // `npx --prefix` at the consumer's package, so tsx is resolved from the
+  // consumer's node_modules.
+
+  it("returns the directory containing package.json closest to the script", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "find-pkg-root-"));
+    try {
+      const pkgDir = path.join(tmp, "scripts", "orchestrator");
+      fs.mkdirSync(path.join(pkgDir, "src"), { recursive: true });
+      fs.writeFileSync(path.join(pkgDir, "package.json"), "{}");
+      const scriptPath = path.join(pkgDir, "src", "main.ts");
+      fs.writeFileSync(scriptPath, "");
+
+      expect(findScriptPackageRoot(scriptPath)).toBe(pkgDir);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("prefers the nearest package.json over outer ones (monorepo case)", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "find-pkg-root-"));
+    try {
+      fs.writeFileSync(path.join(tmp, "package.json"), "{}");
+      const innerPkg = path.join(tmp, "packages", "engine");
+      fs.mkdirSync(path.join(innerPkg, "src"), { recursive: true });
+      fs.writeFileSync(path.join(innerPkg, "package.json"), "{}");
+      const scriptPath = path.join(innerPkg, "src", "main.ts");
+      fs.writeFileSync(scriptPath, "");
+
+      expect(findScriptPackageRoot(scriptPath)).toBe(innerPkg);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("returns null when no package.json exists between the script and the filesystem root", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "find-pkg-root-"));
+    try {
+      const scriptPath = path.join(tmp, "deep", "nest", "main.ts");
+      fs.mkdirSync(path.dirname(scriptPath), { recursive: true });
+      fs.writeFileSync(scriptPath, "");
+
+      expect(findScriptPackageRoot(scriptPath)).toBeNull();
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });

--- a/src/create-main.ts
+++ b/src/create-main.ts
@@ -36,6 +36,49 @@ export function buildNotificationScript(name: string, message: string): string {
   return `display notification "${message}" with title "${safeTitle}"`;
 }
 
+/**
+ * Exported for testing. Walks up from the script's directory toward the
+ * filesystem root and returns the first ancestor containing a `package.json`.
+ * Returns `null` if none is found.
+ */
+export function findScriptPackageRoot(scriptPath: string): string | null {
+  let dir = path.dirname(path.resolve(scriptPath));
+  const { root } = path.parse(dir);
+  while (true) {
+    if (fs.existsSync(path.join(dir, "package.json"))) {
+      return dir;
+    }
+    if (dir === root) return null;
+    dir = path.dirname(dir);
+  }
+}
+
+/**
+ * Exported for testing. Builds the spawn command + args for the --detach
+ * respawn. A TypeScript entry point is routed through `npx tsx` because plain
+ * `node` cannot load `.js` import specifiers that resolve to `.ts` files.
+ * The `--prefix` points at the script's nearest package root so npx resolves
+ * `tsx` from the consumer's `node_modules` rather than from the cwd's.
+ */
+export function buildDetachSpawnCommand(opts: {
+  scriptPath: string;
+  configName: string;
+  childArgv: string[];
+  nodeExecPath: string;
+  findPackageRoot: (scriptPath: string) => string | null;
+}): { command: string; args: string[] } {
+  const { scriptPath, configName, childArgv, nodeExecPath, findPackageRoot } = opts;
+  const isTypescript = /\.[mc]?tsx?$/i.test(scriptPath);
+  if (!isTypescript) {
+    return { command: nodeExecPath, args: [scriptPath, configName, ...childArgv] };
+  }
+  const pkgRoot = findPackageRoot(scriptPath);
+  const args = pkgRoot
+    ? ["--prefix", pkgRoot, "tsx", scriptPath, configName, ...childArgv]
+    : ["tsx", scriptPath, configName, ...childArgv];
+  return { command: "npx", args };
+}
+
 export interface MainOptions {
   configs: Record<string, ConfigFactory>;
   argv?: string[];
@@ -352,16 +395,19 @@ export async function createMain(options: MainOptions): Promise<void> {
       delete env.CLAUDE_CODE_ENTRYPOINT;
 
       const childArgv = restArgv.filter((a) => a !== "--detach");
-      const child = spawn(
-        process.execPath,
-        [scriptPath, configName, ...childArgv],
-        {
-          detached: true,
-          stdio: ["ignore", logFd, logFd],
-          cwd: projectRoot,
-          env,
-        },
-      );
+      const { command, args: spawnArgs } = buildDetachSpawnCommand({
+        scriptPath,
+        configName,
+        childArgv,
+        nodeExecPath: process.execPath,
+        findPackageRoot: findScriptPackageRoot,
+      });
+      const child = spawn(command, spawnArgs, {
+        detached: true,
+        stdio: ["ignore", logFd, logFd],
+        cwd: projectRoot,
+        env,
+      });
 
       if (!child.pid) {
         console.error("Failed to spawn detached process");


### PR DESCRIPTION
## Summary

- The \`--detach\` respawn used \`process.execPath\` (plain \`node\`), which can't load \`.ts\` files: \`.js\` import specifiers resolve literally and the detached process crashes immediately with \`ERR_MODULE_NOT_FOUND\` (see #55).
- This PR detects TypeScript entry points (\`.ts\`, \`.mts\`, \`.cts\`, \`.tsx\`) and routes the respawn through \`npx --prefix <pkgRoot> tsx\` so the consumer project's installed tsx handles loader duties. Compiled \`.js\` consumers continue to use \`process.execPath\` so they don't pay an npx round-trip on every detach.
- Extracts \`buildDetachSpawnCommand\` and \`findScriptPackageRoot\` as pure functions and adds 15 new tests (matching the existing \`buildGhIssueCreateCommand\` / \`buildNotificationScript\` testing pattern).

## Test plan

- [x] \`npm test\` — 628 passing (was 613; +15 new).
- [x] \`npm run typecheck\` — clean.
- [ ] Verified locally against the workaround consumer (daisysguide/launchpad) by re-running the wave with \`--detach\` after a local-link of this branch.

Closes #55